### PR TITLE
chore: schedule nightly feature-parity check on server

### DIFF
--- a/deploy/parity-check.service
+++ b/deploy/parity-check.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Bull Machine Backtest/Live Feature-Parity Check
+After=network.target coinbase-paper.service
+Wants=coinbase-paper.service
+
+[Service]
+Type=oneshot
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/home/ubuntu/Bull-machine-
+Environment=PYTHONPATH=/home/ubuntu/Bull-machine-
+Environment=PATH=/home/ubuntu/Bull-machine-/.venv/bin:/usr/local/bin:/usr/bin:/bin
+
+# Runs on the server: live_features is local, so no --pull. Compares the live
+# feature stream against the local V14 store. Exit 0/1/2 = OK/WARN/FAIL; a
+# non-zero exit surfaces in `systemctl status parity-check` and journald.
+ExecStart=/home/ubuntu/Bull-machine-/.venv/bin/python3 scripts/rebuild/parity_check.py
+
+# Logging via journald
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bull-machine-parity-check
+
+# Resource limits (memory-optimized load peaks ~15MB, but leave headroom)
+MemoryMax=300M
+TimeoutStartSec=180
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/parity-check.timer
+++ b/deploy/parity-check.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Bull Machine feature-parity check nightly at 00:45 UTC
+
+[Timer]
+# 00:45 UTC — after the 00:15 daily quant review, so the day's last candle and
+# its logged feature row are in place.
+OnCalendar=*-*-* 00:45:00 UTC
+Persistent=true
+AccuracySec=60
+
+[Install]
+WantedBy=timers.target

--- a/scripts/rebuild/parity_check.py
+++ b/scripts/rebuild/parity_check.py
@@ -141,7 +141,12 @@ def main():
         pull_from_server()
 
     live = load_live()
-    base = pd.read_parquet(V14)
+    # Memory-safe load: only the columns we actually compare (VM has 1GB RAM —
+    # loading all 295 cols of V14 would peak ~400MB; this keeps it under ~15MB).
+    import pyarrow.parquet as _pq
+    avail = set(_pq.ParquetFile(V14).schema.names)
+    need = [c for c in MONITOR if c in avail]
+    base = pd.read_parquet(V14, columns=need) if need else pd.read_parquet(V14)
     if getattr(base.index, "tz", None) is None:
         base.index = base.index.tz_localize("UTC")
 


### PR DESCRIPTION
Adds a systemd timer to run the backtest/live feature-parity check nightly on the Oracle server.

- `deploy/parity-check.service` (oneshot) + `deploy/parity-check.timer` (00:45 UTC, after the daily quant review)
- `parity_check.py` now loads only the ~15 monitored columns from V14 (~10MB vs ~400MB) so it runs safely within the 1GB VM
- Runs server-side: live_features is local (no --pull); exit 0/1/2 = OK/WARN/FAIL surfaced via journald

Server-side install (V14 store scp'd, units enabled) done separately — the parquet is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)