### PR TITLE
feat: deploy lean core2 paper config

### DIFF
--- a/configs/champion_paper.json
+++ b/configs/champion_paper.json
@@ -1,0 +1,299 @@
+{
+  "version": "v13_penalties",
+  "description": "v13 ALL 16 archetypes ENABLED (7 calibrated + 9 shadow/observation). temp_range=0.38. Calibrated OOS: PF=1.43, Sharpe=1.34, MaxDD=-8.8%",
+  "fix_date": "2026-02-20",
+  "fixes_applied": [
+    "Added relative score filtering (top 70% of signals)",
+    "Added per-archetype cooling periods (24H default)",
+    "Added regime-dependent fusion thresholds",
+    "Target: 40-80 trades on Jan 2023 (was 931)",
+    "CAPITAL OVERHAUL 2026-02-06: max_positions 3->8, dynamic sizing, 2x leverage, runner positions",
+    "CAPITAL OVERHAUL 2026-02-06: Archetype-specific exit logic (trend vs mean-reversion vs hybrid)",
+    "CAPITAL OVERHAUL 2026-02-06: fusion_size_tiers for conviction-based position sizing"
+  ],
+  "archetype_config_dir": "configs/champion/archetypes_v14rq/",
+  "use_isolated_fusion": true,
+  "use_ml_fusion": false,
+  "ml_fusion_model_path": "models/fusion_scorer_xgb.pkl",
+  "ml_fusion_blend_weight": 0.6,
+  "ml_fusion_notes": "DISABLED 2026-02-06: Trained on old data, hurting performance",
+  "signal_dedup": {
+    "mode": "best_per_direction",
+    "notes": "Modes: best_of_bar | best_per_direction | unique_sl_zone | disabled. Max 1 long + 1 short per bar."
+  },
+  "portfolio_allocation": {
+    "mode": "MULTI_UNCORRELATED",
+    "correlation_threshold": 0.5,
+    "max_simultaneous_positions": 5,
+    "enable_correlation_filter": false,
+    "relative_score_percentile": 0.0,
+    "dynamic_sizing_enabled": true,
+    "fusion_size_tiers": [
+      {
+        "min_fusion": 0.6,
+        "multiplier": 2.0
+      },
+      {
+        "min_fusion": 0.4,
+        "multiplier": 1.5
+      },
+      {
+        "min_fusion": 0.18,
+        "multiplier": 1.0
+      }
+    ],
+    "notes": [
+      "2026-03-06: PRODUCTION MODE \u2014 threshold active, 8 calibrated archetypes, max 3 positions",
+      "Data collection mode ended: 79 trades, 33% WR, -$4,488. Bypass mode was catastrophic.",
+      "Enabled: wick_trap, liquidity_sweep, retest_cluster, trap_within_trend, spring, failed_continuation, order_block_retest, liquidity_vacuum"
+    ]
+  },
+  "disabled_archetypes": [
+    "confluence_breakout",
+    "exhaustion_reversal",
+    "failed_continuation",
+    "funding_divergence",
+    "fvg_continuation",
+    "liquidity_compression",
+    "liquidity_vacuum",
+    "long_squeeze",
+    "oi_divergence",
+    "order_block_retest",
+    "retest_cluster",
+    "spring",
+    "trap_within_trend",
+    "volume_fade_chop",
+    "whipsaw"
+  ],
+  "_disabled_archetypes_note": "2026-03-06: PRODUCTION MODE. bypass_threshold=false. 8 calibrated archetypes enabled, 9 disabled. Data collection mode (79 trades, 33% WR, -$4.5K) proved bypass is catastrophic.",
+  "_calibrated_archetypes": [
+    "trap_within_trend",
+    "liquidity_vacuum",
+    "retest_cluster",
+    "failed_continuation",
+    "wick_trap",
+    "spring",
+    "order_block_retest",
+    "liquidity_sweep"
+  ],
+  "_shadow_uncalibrated_archetypes": [
+    "long_squeeze",
+    "funding_divergence",
+    "fvg_continuation",
+    "volume_fade_chop",
+    "whipsaw",
+    "liquidity_compression",
+    "exhaustion_reversal",
+    "confluence_breakout",
+    "oi_divergence"
+  ],
+  "_shadow_notes": [
+    "CALIBRATED (7): Have per-archetype base_threshold, backtest-validated PF>1.0 OOS",
+    "SHADOW (9): Use default base_threshold=0.18, historically unprofitable, enabled for observation only",
+    "long_squeeze: SHADOW \u2014 SHORT archetype, PF<0.7 on 2020-2024 bull data",
+    "funding_divergence: SHADOW \u2014 PF=0.99, regime filter misaligned",
+    "confluence_breakout: SHADOW \u2014 PF=0.93, unprofitable with fixed features",
+    "fvg_continuation: SHADOW \u2014 PF=0.95, net loser (-$3K on 684 trades)",
+    "exhaustion_reversal: SHADOW \u2014 PF=0.89, net loser (-$3.8K on 370 trades)",
+    "liquidity_compression: SHADOW \u2014 PF=0.95, marginal at best",
+    "liquidity_sweep: SHADOW \u2014 PF=0.91 at temp_range=0.38, dropped from calibrated",
+    "volume_fade_chop: SHADOW \u2014 no reliable backtest data",
+    "whipsaw: SHADOW \u2014 no reliable backtest data"
+  ],
+  "adaptive_fusion": {
+    "enabled": true,
+    "crisis_coefficient": 0.5,
+    "base_threshold": 0.18,
+    "crisis_prob_source": "original",
+    "_crisis_prob_source_note": "2026-06-02: 'original' (default, bit-exact baseline) or 'substitute_no_derivatives' (macro+sentiment+structural+vol-shock composite for when derivatives_heat is disabled). See engine/context/regime_service.py docstring.",
+    "crisis_prob_substitute": {
+      "w_macro": 0.25,
+      "w_sentiment": 0.35,
+      "w_structural": 0.3,
+      "w_vol_shock": 0.1,
+      "a_dxy": 0.6,
+      "a_vix": 0.4,
+      "b_ema_slope": 15.0,
+      "b_wyckoff_breakdown": 1.0,
+      "fear_threshold": 35.0,
+      "rv_floor": 0.75,
+      "rv_range": 0.5,
+      "macro_offset": 1.0,
+      "struct_offset": 0.5,
+      "_validation": "LUNA week 2022-05-09\u219215 mean=0.55 (78.6% bars > 0.5), COVID 2020-03-09\u219220 mean=0.62 (75% > 0.5), Bull 2024 Mar-Apr mean=0.24, Bull 2021 Apr mean=0.17. Live W3 (May28-Jun02 2026) mean=0.27 vs W1 (Apr20-May17) mean=0.23."
+    },
+    "per_archetype_base_threshold": {
+      "trap_within_trend": 0.11,
+      "liquidity_vacuum": 0.09,
+      "retest_cluster": 0.1,
+      "failed_continuation": 0.05,
+      "liquidity_sweep": 0.09,
+      "wick_trap": 0.18,
+      "spring": 0.05,
+      "order_block_retest": 0.11,
+      "oi_divergence": 0.15,
+      "exhaustion_reversal": 0.14,
+      "funding_divergence": 0.04,
+      "fvg_continuation": 0.08,
+      "long_squeeze": 0.2,
+      "confluence_breakout": 0.05
+    },
+    "_threshold_note": "2026-03-06: PRODUCTION MODE. bypass_threshold=false. Only signals above dynamic threshold trade. Data collection (79 trades, 33% WR, -$4.5K) proved bypass is catastrophic.",
+    "bypass_threshold": false,
+    "cmi_weights": {
+      "risk_temp": {
+        "trend_align": 0.3,
+        "trend_strength": 0.05,
+        "sentiment": 0.15,
+        "dd_score": 0.5,
+        "derivatives_heat": 0.0
+      },
+      "instability": {
+        "chop": 0.4,
+        "adx_weakness": 0.1,
+        "wick_score": 0.25,
+        "vol_instab": 0.25
+      },
+      "crisis": {
+        "base_crisis": 0.45,
+        "vol_shock": 0.1,
+        "sentiment_crisis": 0.45
+      }
+    },
+    "cmi_weights_optimized": null,
+    "temp_range": 0.38,
+    "instab_range": 0.15,
+    "base_max_positions": 3,
+    "emergency_crisis_threshold": 0.7,
+    "emergency_size_multiplier": 0.5,
+    "notes": [
+      "UPDATED 2026-02-20: temp_range 0.48\u21920.38. 0.48 blocked ALL live trades (threshold=0.45-0.69 in non-bull). Now threshold ~0.42 in neutral, achievable by strong signals.",
+      "threshold = base_threshold + (1 - risk_temp) * temp_range + instability * instab_range",
+      "crisis penalty: adjusted_fusion = fusion * (1 - crisis_prob * crisis_coefficient)",
+      "risk_temperature: dd_score(50%) + trend_align(30%) + sentiment(15%) + adx(5%) + derivatives_heat(0%) [DATA-INFORMED 2026-02-21, deriv_heat ready but DISABLED pending more data]",
+      "instability: chop(40%) + wick(25%) + vol_z(25%) + adx_weakness(10%) [DATA-INFORMED, instab_range 0.20->0.15]",
+      "crisis_prob: base_crisis(45%) + sentiment_crisis(45%) + vol_shock(10%) [DATA-INFORMED, crisis_coeff 0.40->0.50]",
+      "Position limits: stress-scaled continuous (base=3, scales down with stress, min=1)",
+      "Emergency cap: crisis_prob > 0.7 \u2192 50% sizing multiplier",
+      "Wyckoff/temporal/SMC stay in archetype fusion ONLY \u2014 prevents double-counting",
+      "SMA regime labels kept for logging/diagnostics only"
+    ],
+    "state_machine_enabled": true,
+    "sm_max_structure_bars": 1000,
+    "sm_ar_max_bars": 15,
+    "sm_st_volume_ratio": 0.7,
+    "sm_invalidation_vol_ratio": 0.8,
+    "sm_spring_max_break_pct": 0.05,
+    "sc_range_lookback": 50,
+    "bc_range_lookback": 50,
+    "spring_a_breakdown_margin": 0.015,
+    "spring_a_volume_z_min": 0.5,
+    "ut_breakout_margin": 0.015,
+    "ut_volume_z_min": 0.5
+  },
+  "max_positions_by_regime": {
+    "notes": [
+      "REPLACED 2026-02-11 by stress-scaled continuous limit in adaptive_fusion",
+      "base_max_positions=3, scales down with stress_level=max(crisis_prob, instability*0.5)",
+      "Old values kept for reference: crisis=1, risk_off=1, neutral=3, risk_on=3"
+    ]
+  },
+  "cooling_periods": {
+    "default_bars": 24,
+    "archetype_overrides": {
+      "spring": 36,
+      "wick_trap": 18,
+      "long_squeeze": 48,
+      "notes": [
+        "spring: Rare setup, allow longer cooldown (36H)",
+        "wick_trap: Higher frequency pattern, shorter cooldown (18H)",
+        "long_squeeze: Extreme event, long cooldown (48H)"
+      ]
+    }
+  },
+  "regime_classifier": {
+    "enabled": true,
+    "mode": "probabilistic",
+    "model_path": "models/logistic_regime_v4_no_funding_stratified.pkl",
+    "use_soft_controls": true,
+    "notes": [
+      "Enabled regime classifier for dynamic threshold adaptation",
+      "Probabilistic mode for smooth regime transitions"
+    ]
+  },
+  "position_sizing": {
+    "risk_per_trade_pct": 0.02,
+    "max_margin_per_position_pct": 0.35,
+    "max_position_size_pct": 0.15,
+    "use_atr_scaling": true,
+    "dynamic_sizing_enabled": true,
+    "fusion_size_tiers": [
+      {
+        "min_fusion": 0.6,
+        "size_multiplier": 2.0,
+        "label": "high_conviction"
+      },
+      {
+        "min_fusion": 0.4,
+        "size_multiplier": 1.5,
+        "label": "moderate_conviction"
+      },
+      {
+        "min_fusion": 0.18,
+        "size_multiplier": 1.0,
+        "label": "base_conviction"
+      }
+    ],
+    "notes": [
+      "UPDATED 2026-02-06: max_position_size reduced 0.20->0.15 (76% SL hit rate needs smaller risk)",
+      "dynamic_sizing_enabled: fusion score drives position size multiplier",
+      "fusion >= 0.60: 2x base size (high conviction, rare but impactful)",
+      "fusion >= 0.40: 1.5x base size (moderate conviction)",
+      "fusion >= 0.18: 1x base size (meets threshold, standard sizing)"
+    ]
+  },
+  "leverage": 1.5,
+  "leverage_notes": "2026-02-27: REVERTED to 1.5x (Phase 1). Previous 3.0x was premature \u2014 live PF=0.45 with 29.6% WR. Stay at 1.5x until live PF>1.3 for 30+ days.",
+  "runner_position_enabled": true,
+  "exit_logic": {
+    "use_archetype_specific": true,
+    "trailing_stop_enabled": true,
+    "scale_out_enabled": true,
+    "notes": [
+      "UPDATED 2026-02-06: Moderate exits (76% SL hit rate with old params)",
+      "Trend-following: [1.5R, 3R, 5R] exits, 14-day holds, 15% runner positions",
+      "Mean-reversion: [1R, 2R, 3R] exits, 5-day holds, no runners",
+      "Hybrid: [1.5R, 2.5R, 4R] exits, 10-day holds, 10% runners"
+    ]
+  },
+  "notes": [
+    "v11 FIXED - capital deployment overhaul",
+    "PROBLEM: 35% return over 5 years on BTC (which went 13x) due to idle capital",
+    "ROOT CAUSES: max 3 positions (82% idle), identical 7-day exits, no dynamic sizing",
+    "FIX 1: 8 simultaneous positions (was 3) - deploy more capital",
+    "FIX 2: Archetype-specific exits - trend followers hold 21 days with runners",
+    "FIX 3: Dynamic position sizing based on fusion conviction score",
+    "FIX 4: 2x leverage for capital efficiency",
+    "FIX 5: 20% runner positions to capture extended trends",
+    "FIX 6: Regime position limits expanded (risk_on: 6, neutral: 5, risk_off: 3, crisis: 2)",
+    "Each archetype calculates its own fusion score (no shared fusion_total)",
+    "Portfolio allocator filters correlated signals AND weak signals",
+    "Cooling periods prevent rapid-fire signals from same archetype"
+  ],
+  "structural_checks": {
+    "enabled": true,
+    "gate_params": {
+      "bos_atr_B": 2.9912363698443576,
+      "funding_z_S4": -1.8167981029619473,
+      "funding_z_S5": 1.450900520468517,
+      "rsi_lower_F": 24.528581875434863,
+      "rsi_lower_L": 32.968023961114554,
+      "rsi_upper_F": 77.49735985126347,
+      "rsi_upper_L": 65.68071845610109,
+      "vol_z_L": 1.2794004516616884,
+      "wick_pct_G": 0.38184757169438016,
+      "wick_pct_K": 0.4910969436357509
+    }
+  },
+  "_champion_paper_note": "2026-06-30 LEAN PAPER CONFIG: core2 (wick_trap_v14rq @0.432 + liquidity_sweep), thresholds ENFORCED. Validated: full PF 1.41, holdout 1.30 (+$6.8K), MaxDD 17%. Breakeven-1R exit on wick_trap = phase 2 (code change)."
+}

--- a/deploy/coinbase-paper.service
+++ b/deploy/coinbase-paper.service
@@ -13,6 +13,7 @@ Environment=PATH=/home/ubuntu/Bull-machine-/.venv/bin:/usr/local/bin:/usr/bin:/b
 
 ExecStart=/home/ubuntu/Bull-machine-/.venv/bin/python3 bin/live/coinbase_runner.py \
     --paper \
+    --config configs/champion_paper.json \
     --initial-cash 100000 \
     --commission-rate 0.0002 \
     --slippage-bps 3


### PR DESCRIPTION
Switches live paper trading to the validated lean book (wick_trap_v14rq + liquidity_sweep, thresholds enforced). Backtest-verified to reproduce core2 exactly (full PF 1.41, holdout PF 1.30). Config-only; live engine reads the same keys as the backtester. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new paper-trading setup with expanded strategy coverage, adaptive trade sizing, and improved entry/exit behavior.
  * Enabled more selective signal handling and refined risk controls for different market conditions.
* **Bug Fixes**
  * Updated the paper-trading service to launch with the new configuration by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->