### PR TITLE
study: downtrend fix — 200d skip works, naive short has no edge

### DIFF
--- a/docs/knowledge/MEMORY.md
+++ b/docs/knowledge/MEMORY.md
@@ -267,6 +267,9 @@ Live code had stale hardcoded CMI weights. Backtester reads from config (correct
 ## Live Deployment
 - **2026-06-30 LIVE PAPER CONFIG** (`configs/champion_paper.json`, service `--config`): FULL BOOK — all 16 archetypes enabled, bypass_threshold=True (data collection), archetype_config_dir=archetypes_v14rq so wick_trap + trap_within_trend now FIRE at re-quantiled 0.43 (were locked out at 0.72). [History: briefly deployed lean core2-only, then user reverted to full-book-plus-unlocked.] deploy.sh excludes deploy/ so the service file installs MANUALLY (scp+systemctl). Breakeven-1R exit = phase 2 (not deployed).
 
+## Direction Fix
+- [Downtrend study 2026-07-02](downtrend_study_2026_07_02.md) — DEFENSIVE SKIP works, naive SHORT does not. skip longs when price < 200-day mean: 2022 -$43K->$0, MaxDD 51%->16.4%, full PnL $163K->$198K, PF 1.16->1.29 (holdout -$14K->-$8.4K, still neg = bleed-STOP not profit engine). SHORT feasibility: fwd returns during downtrends are ~coin flip (49% neg, ~0% mean) — being below 200d does NOT predict imminent downside; naive regime-short has NO edge, would lose to fees. DEPLOY the skip; do NOT build a blind short (needs a precise setup, unproven).
+
 ## Live Trade Forensics
 - [Last-30 live forensic 2026-07-02](live_trade_forensic_2026_07_02.md) — net -$10,362 (9W/21L), ALL long into a -22.8% BTC decline. AT ENTRY effectively RANDOM: no feature predicts win/loss; fusion is INVERTED (the 5 trades clearing the enforced threshold were ALL losers, -$5,886). Dominant failure mode: 18 longs straight to stop (-$18.2K). 6 real runners (+$7.9K) prove triggers work when market cooperates. Good archetypes (wick_trap/liq_sweep) ABSENT (locked out live-path). Turning bypass OFF would delete all 9 winners + keep 5 worst losers. Lever = direction/regime SKIP in downtrends + fix live-path; exits minor (only 3 gave back a +1R winner).
 

--- a/docs/knowledge/downtrend_study_2026_07_02.md
+++ b/docs/knowledge/downtrend_study_2026_07_02.md
@@ -1,0 +1,64 @@
+# Downtrend Study — Defensive Skip WORKS, Naive Short has NO Edge
+
+**Date**: 2026-07-02
+**Purpose**: scope the direction-fix — (1) build a downtrend detector, (2) test skipping longs
+in downtrends (defensive), (3) test whether shorting downtrends has edge (offensive).
+**Artifact**: `results/champion_v14_downtrend/`, `scripts/champion/downtrend_study.py`. Full-16 book, thresholds enforced, V14.
+
+## STEP 1 — Detector: 200-day is the cleanest
+% of bars flagged "downtrend": dt_200d fires 100% of 2022, 72% of 2018 (real bears) but only
+23% of 2020 (bull) — best regime separation. dt_50d/dt_death are noisier (flag ~33% of the 2020
+bull). **Use price < 200-day mean.**
+
+## STEP 3 — SHORT FEASIBILITY: no naive edge (important)
+Forward returns DURING detected downtrends:
+| detector | fwd 24h | fwd 72h | % negative (72h) |
+|---|---|---|---|
+| dt_200d | +0.03% | +0.10% | 49% |
+| dt_50d | −0.03% | −0.05% | 49% |
+| dt_death | +0.03% | +0.06% | 48% |
+
+**Being below the 200-day mean does NOT predict the next few days are down — it's a coin flip
+(~49% negative, ~0% mean).** BTC spends long stretches below its 200d mean chopping sideways and
+ripping bear-market rallies. So a naive "short the downtrend regime" has NO edge and would lose to
+fees/funding. **The right posture in a downtrend is CASH (skip), not SHORT.** A profitable short
+needs a precise short SETUP predicting imminent downside — a separate, harder study with no evidence
+yet that such an edge exists. DO NOT build a blind regime-short.
+
+## STEP 2 — DEFENSIVE SKIP: strong, deployable (the win)
+Full-16 book, skip long entries when detector fires:
+| variant | 2018 | 2022 | holdout | full PnL | full PF | MaxDD |
+|---|---|---|---|---|---|---|
+| baseline | −40,389 | −43,156 | −14,366 | 163,279 | 1.16 | **51.2%** |
+| **skip_dt_200d** | **−7,485** | **0** | −8,427 | **197,891** | **1.29** | **16.4%** |
+| skip_dt_50d | −35,512 | −21,602 | −6,902 | 189,601 | 1.26 | 42.0% |
+| skip_dt_death | −20,977 | −26,382 | −1,735 | 174,178 | 1.23 | 28.5% |
+
+**skip_dt_200d is the clear winner and a genuinely strong fix:**
+- 2022 (worst bear): −$43,156 → **$0** (stayed in cash all year)
+- 2018: −$40,389 → −$7,485
+- **MaxDD: 51% → 16.4%** — cut portfolio-destroying drawdown by two-thirds
+- Full PnL: $163K → **$198K** — MORE money (avoiding the big losses beats the skipped bull-pullback longs)
+- Full PF: 1.16 → 1.29
+- Holdout 2025-26: −$14.4K → −$8.4K (much better, still negative — 2025-26 was often above 200d so fewer skips)
+
+## Bottom line
+1. **DEPLOY the 200-day downtrend skip.** It doesn't make money in bears but it STOPS THE BLEED —
+   cuts drawdown 51%→16%, turns 2022 from −$43K to flat, and raises total profit. Highest-value
+   deployable change found. (Note: on the LIVE full book in bypass mode this would prevent the
+   long-into-bear losses the [[live_trade_forensic_2026_07_02]] documented.)
+2. **Do NOT build a naive short.** Downtrend regime ≠ imminent downside (coin flip). Shorting needs
+   a precise setup, not the regime tag.
+3. Holdout still slightly negative — the skip is a bleed-STOP, not a profit engine. Profit in bears
+   still requires either a real short SETUP (unproven) or waiting for the regime to turn.
+
+## Caveats
+- Detector uses price < 200-day mean at bar close (concurrent, no lookahead). Simple/standard,
+  low overfit risk, but only ONE definition swept for the winner.
+- Needs quant-analyst adjudication + CPCV before production (per discipline). n of bear years is small (2018, 2022, 2025-26 partial).
+- Skip is a real entry-block (position never opens), not size=0.
+
+## Cross-references
+[[live_trade_forensic_2026_07_02]] (18 longs-straight-to-stop this addresses) ·
+[[sizing_studies_verdict_2026_06_16]] (regime sizing couldn't flip bears; this SKIPS instead) ·
+[[risk_overlay_verdict_2026_06_27]]

--- a/scripts/champion/downtrend_study.py
+++ b/scripts/champion/downtrend_study.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Downtrend scoping study (V14) — the direction fix.
+
+Every prior study says the bleed is long-only-into-downtrends, not bad signals.
+This scopes the fix in three parts, cheapest first:
+
+  STEP 1 — DOWNTREND DETECTOR: a few candidate definitions from V14 price.
+  STEP 2 — DEFENSIVE SKIP: skip long entries when the detector fires. Does it
+           cut the loss / drawdown across 2018-2026 (esp. bears)? Real skip
+           (position never opens — no size=0 accounting bug).
+  STEP 3 — OFFENSIVE FEASIBILITY: during detected downtrends, what does price do
+           next (fwd 24h/72h return)? If reliably negative, shorting has edge —
+           the go/no-go for building a short side.
+
+Read-only research; full-16 book, thresholds as configured. No production change.
+Usage: python3 scripts/champion/downtrend_study.py
+"""
+from __future__ import annotations
+import json, math, sys
+from pathlib import Path
+import numpy as np, pandas as pd
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO)); sys.path.insert(0, str(REPO/"scripts/champion"))
+from run_battery import ALL_ARCHETYPES, BASE_CONFIG, CONFIG_DIR, score
+
+STORE = REPO/"data/features_mtf/BTC_1H_FEATURES_V14_FULL_LIVE_PATH.parquet"
+OUT = REPO/"results/champion_v14_downtrend"
+WINDOWS = {"y2018":("2018-01-01","2018-12-31"),"y2019":("2019-01-01","2019-12-31"),
+           "y2020":("2020-01-01","2020-12-31"),"y2021":("2021-01-01","2021-12-31"),
+           "y2022":("2022-01-01","2022-12-31"),"y2023":("2023-01-01","2023-12-31"),
+           "y2024":("2024-01-01","2024-12-31"),"wfo_train":("2018-01-01","2022-12-31"),
+           "holdout_2025_26":("2025-01-01","2026-06-10"),"full":("2018-01-01","2024-12-31")}
+
+_DET = {}
+def detectors():
+    """Return dict name -> boolean downtrend Series over the full store."""
+    if _DET: return _DET
+    df = pd.read_parquet(STORE, columns=["close","ema_50_above_200"])
+    if df.index.tz is not None: df.index = df.index.tz_localize(None)
+    c = df["close"]
+    _DET["dt_200d"] = c < c.rolling(200*24, min_periods=100*24).mean()   # macro
+    _DET["dt_50d"]  = c < c.rolling(50*24,  min_periods=25*24).mean()    # faster
+    _DET["dt_death"] = df["ema_50_above_200"].fillna(1) == 0             # death cross
+    # combo: 200d AND price falling (below 50d too) = high-conviction downtrend
+    _DET["dt_combo"] = _DET["dt_200d"] & _DET["dt_50d"]
+    return _DET
+
+def full_cfg():
+    cfg = json.loads(BASE_CONFIG.read_text()); cfg["disabled_archetypes"]=[]
+    cfg.setdefault("adaptive_fusion",{})["bypass_threshold"]=False  # enforced (clean read)
+    cfg["archetype_config_dir"]="configs/champion/archetypes_v14rq/"
+    CONFIG_DIR.mkdir(parents=True,exist_ok=True)
+    p=CONFIG_DIR/"downtrend_full.json"; p.write_text(json.dumps(cfg,indent=2)); return p
+
+def install_skip(dt: pd.Series):
+    """Patch _open_position to SKIP long opens when downtrend fires (real skip)."""
+    from bin.backtest_v11_standalone import StandaloneBacktestEngine
+    orig = StandaloneBacktestEngine._open_position
+    st = {"seen":0,"skipped":0}
+    def patched(self,*a,**k):
+        ts = k.get("timestamp") or (a[0] if a else None)
+        direction = k.get("direction") or (a[2] if len(a)>2 else None)
+        st["seen"]+=1
+        if direction=="long" and ts is not None:
+            try:
+                if bool(dt.at[ts]):
+                    st["skipped"]+=1; return None    # skip: position never opens
+            except KeyError: pass
+        return orig(self,*a,**k)
+    StandaloneBacktestEngine._open_position = patched
+    return st, lambda: setattr(StandaloneBacktestEngine,"_open_position",orig)
+
+def run(cfg,start,end,out_dir,dt=None):
+    from bin.backtest_v11_standalone import StandaloneBacktestEngine
+    out_dir.mkdir(parents=True,exist_ok=True); sf=out_dir/"performance_stats.json"
+    if sf.exists(): return json.loads(sf.read_text())
+    restore = install_skip(dt)[1] if dt is not None else (lambda:None)
+    try:
+        eng=StandaloneBacktestEngine(config=json.loads(cfg.read_text()),initial_cash=100000.0,
+            commission_rate=0.0002,slippage_bps=3.0,feature_store_path=str(STORE))
+        eng.run(start_date=start,end_date=end); stats=eng.get_performance_stats()
+    finally: restore()
+    clean={kk:(str(v) if isinstance(v,float) and (math.isnan(v) or math.isinf(v)) else v) for kk,v in stats.items()}
+    sf.write_text(json.dumps(clean,indent=2,default=str)); return clean
+
+def main():
+    OUT.mkdir(parents=True,exist_ok=True); cfg=full_cfg(); dets=detectors()
+    # coverage: what fraction of bars each detector flags, and per-year
+    print("=== STEP 1: detector coverage (% bars flagged downtrend) ===")
+    for n,s in dets.items():
+        by=s.groupby(s.index.year).mean()
+        print(f"  {n:<10} overall {100*s.mean():4.0f}% | 2018 {100*by.get(2018,0):3.0f} 2020 {100*by.get(2020,0):3.0f} 2022 {100*by.get(2022,0):3.0f} 2025 {100*by.get(2025,0):3.0f}")
+
+    print("\n=== STEP 3: SHORT FEASIBILITY — fwd returns during detected downtrends ===")
+    px = pd.read_parquet(STORE, columns=["close"]);
+    if px.index.tz is not None: px.index=px.index.tz_localize(None)
+    c=px["close"]; f24=c.shift(-24)/c-1; f72=c.shift(-72)/c-1
+    print(f"  {'detector':<10}{'baseline_all':>14}{'in_downtrend_24h':>18}{'72h':>10}{'%neg_72h':>10}")
+    base24=f24.mean()
+    for n,s in dets.items():
+        m=s & f72.notna()
+        print(f"  {n:<10}{100*base24:>13.2f}%{100*f24[m].mean():>17.2f}%{100*f72[m].mean():>9.2f}%{100*(f72[m]<0).mean():>9.0f}%")
+    print("  (if in-downtrend fwd returns are reliably NEGATIVE, a short side has edge)")
+
+    print("\n=== STEP 2: DEFENSIVE SKIP — full-16 book, skip longs in downtrend ===")
+    variants={"baseline":None, **{f"skip_{n}":s for n,s in dets.items()}}
+    cards={}
+    for vn,dt in variants.items():
+        res={w:run(cfg,s,e,OUT/vn/w,dt) for w,(s,e) in WINDOWS.items()}
+        cards[vn]=score(vn,res)["detail"]
+    print(f"{'variant':<16}{'2018':>8}{'2022':>8}{'hold_pnl':>9}{'full_pnl':>9}{'full_pf':>8}{'mdd':>6}")
+    for vn,d in cards.items():
+        print(f"{vn:<16}{d['y2018']['pnl']:>8}{d['y2022']['pnl']:>8}{d['holdout_2025_26']['pnl']:>9}"
+              f"{d['full']['pnl']:>9}{d['full']['pf']:>8}{d['full']['maxdd_pct']:>6}")
+    (OUT/"summary.json").write_text(json.dumps(cards,indent=2,default=str))
+    print(f"\nreport -> {OUT/'summary.json'}")
+
+if __name__=="__main__": main()


### PR DESCRIPTION
Scoped the direction fix in three parts.

**Defensive skip (DEPLOY):** skip long entries when price < 200-day mean —
| | 2022 | full PnL | MaxDD |
|---|---|---|---|
| baseline | -$43K | $163K | 51% |
| skip 200d | **$0** | **$198K** | **16.4%** |

Cuts drawdown by 2/3, turns the worst bear year from -$43K to flat, and raises total profit. Strong, deployable bleed-stop.

**Offensive short (DON'T build naive version):** forward returns during detected downtrends are a coin flip (49% negative, ~0% mean). Being below the 200-day mean does NOT predict imminent downside — a blind regime-short has no edge and would lose to fees. Shorting needs a precise setup, not the regime tag.

**Honest limit:** the skip is a bleed-STOP, not a profit engine — holdout still -$8.4K (better than -$14K). Profit in bears needs a real short setup (unproven) or the regime turning. Needs quant adjudication + CPCV before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new downtrend analysis and guidance update.
  * Introduced a defensive approach for downtrend periods that skips long entries when trend conditions are unfavorable.
  * Expanded study notes with performance results showing improved drawdown control and better overall outcomes versus the baseline.

* **Documentation**
  * Added a new write-up summarizing downtrend behavior, shorting limitations, and recommended next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->