### PR TITLE
validate: wick_trap CPCV — PASS 15/15 (final offline gate)

### DIFF
--- a/docs/knowledge/MEMORY.md
+++ b/docs/knowledge/MEMORY.md
@@ -267,6 +267,9 @@ Live code had stale hardcoded CMI weights. Backtester reads from config (correct
 ## Live Deployment
 - **2026-06-30 LIVE PAPER CONFIG** (`configs/champion_paper.json`, service `--config`): FULL BOOK — all 16 archetypes enabled, bypass_threshold=True (data collection), archetype_config_dir=archetypes_v14rq so wick_trap + trap_within_trend now FIRE at re-quantiled 0.43 (were locked out at 0.72). [History: briefly deployed lean core2-only, then user reverted to full-book-plus-unlocked.] deploy.sh excludes deploy/ so the service file installs MANUALLY (scp+systemctl). Breakeven-1R exit = phase 2 (not deployed).
 
+## Validated Champion
+- [wick_trap CPCV 2026-07-09](wick_trap_cpcv_2026_07_09.md) — PASS 15/15 combinations positive, median PF 1.41, WORST alternate history +$2,421. wick_trap_v14rq standalone (unstacked) has now cleared EVERY offline gate: battery, pristine holdout (PF 1.43), stacking adjudication, CPCV. Remaining evidence = LIVE (already unlocked in full book @0.43). Satellite strategy: bleeds modestly in deep bears; no overlay improves it
+
 ## Direction Fix
 - [Downtrend study 2026-07-02](downtrend_study_2026_07_02.md) — DEFENSIVE SKIP works, naive SHORT does not. skip longs when price < 200-day mean: 2022 -$43K->$0, MaxDD 51%->16.4%, full PnL $163K->$198K, PF 1.16->1.29 (holdout -$14K->-$8.4K, still neg = bleed-STOP not profit engine). SHORT feasibility: fwd returns during downtrends are ~coin flip (49% neg, ~0% mean) — being below 200d does NOT predict imminent downside; naive regime-short has NO edge, would lose to fees. DEPLOY the skip; do NOT build a blind short (needs a precise setup, unproven).
 

--- a/docs/knowledge/wick_trap_cpcv_2026_07_09.md
+++ b/docs/knowledge/wick_trap_cpcv_2026_07_09.md
@@ -1,0 +1,31 @@
+# wick_trap CPCV — PASS (15/15): The Edge Is Not Era-Luck
+
+**Date**: 2026-07-09. **Subject**: standalone wick_trap_v14rq (0.432, unstacked — the config the
+stack-validation verdict ranked #1). **Artifact**: `results/champion_v14_cpcv/`, `scripts/champion/cpcv_wick_trap.py`
+
+## Method
+k=6 contiguous time groups over 2018-01-01..2026-06-10; all C(6,2)=15 two-group test
+combinations evaluated (strategy is FIXED — no parameters fitted, so group-level backtests
+aggregate exactly). Pre-registered bar: >=10/15 combos positive, median PF >= 1.2, worst > -$8K.
+
+## Result: PASS on every criterion, with margin
+- **15/15 combinations positive** (bar: 10)
+- **Median combination PF 1.41** (bar: 1.2)
+- **Worst combination +$2,421** (bar: > -$8K) — the worst alternate history still MAKES money
+- Only one negative group: g4 (2022-03..2023-08, the deep bear) at -$1,916 — modest, and every
+  pairing containing it is still net positive.
+
+## What this means
+wick_trap's 8.5-year record is NOT carried by a lucky era. Combined with the prior gates —
+per-year battery, pristine 2025-26 holdout (PF 1.43, n=70), stacking adjudication (survived
+attempts to "improve" it) — **wick_trap standalone has now cleared every offline validation
+this project knows how to run.** The remaining evidence frontier is LIVE (it is already
+unlocked in the live full book at 0.43; its live trades will accrue).
+
+## Honest limits (unchanged)
+Satellite strategy, not a system: ~55-95 trades/1.4yr, bleeds ~$2-9K in deep-bear stretches,
+full-period MaxDD 14.3%. No overlay tested to date improves it (stack verdict 2026-07-08).
+
+## Cross-references
+[[stack_validation_verdict_2026_07_08]] · [[v14_champion_hunt_2026_06_11]] ·
+[[breakeven_study_verdict_2026_06_29]] (RETRACTED)

--- a/scripts/champion/cpcv_wick_trap.py
+++ b/scripts/champion/cpcv_wick_trap.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""CPCV evaluation of standalone wick_trap_v14rq (no parameters fitted).
+
+Splits 2018-01-01..2026-06-10 into k=6 contiguous time groups; evaluates all
+C(6,2)=15 two-group test combinations. Since the strategy is FIXED (no
+optimization), each group is backtested once and combinations aggregate
+group-level results. A real edge: most combinations positive, no catastrophe.
+
+Acceptance (pre-registered): >=10/15 combinations positive PnL; median
+combination PF >= 1.2; worst combination loss bounded (> -$8K on $100K).
+"""
+from __future__ import annotations
+import itertools, json, math, sys
+from pathlib import Path
+import pandas as pd
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO)); sys.path.insert(0, str(REPO/"scripts/champion"))
+
+STORE = REPO/"data/features_mtf/BTC_1H_FEATURES_V14_FULL_LIVE_PATH.parquet"
+CFG = REPO/"configs/champion/stack_wt_only_none.json"
+OUT = REPO/"results/champion_v14_cpcv"
+
+def run_window(start, end, out_dir):
+    from bin.backtest_v11_standalone import StandaloneBacktestEngine
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sf = out_dir/"performance_stats.json"
+    if sf.exists(): return json.loads(sf.read_text())
+    eng = StandaloneBacktestEngine(config=json.loads(CFG.read_text()), initial_cash=100000.0,
+        commission_rate=0.0002, slippage_bps=3.0, feature_store_path=str(STORE))
+    eng.run(start_date=start, end_date=end)
+    stats = eng.get_performance_stats()
+    clean = {k:(str(v) if isinstance(v,float) and (math.isnan(v) or math.isinf(v)) else v) for k,v in stats.items()}
+    sf.write_text(json.dumps(clean, indent=2, default=str)); return clean
+
+def num(v, d=0.0):
+    try:
+        f=float(v); return d if f!=f else f
+    except (TypeError,ValueError): return d
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    edges = pd.date_range("2018-01-01","2026-06-10",periods=7)
+    groups=[]
+    for i in range(6):
+        s=edges[i].strftime("%Y-%m-%d"); e=(edges[i+1]-pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+        st=run_window(s,e,OUT/f"g{i+1}")
+        groups.append({"g":i+1,"span":f"{s}..{e}","pnl":num(st.get("total_pnl")),
+            "gp":num(st.get("gross_profit")),"gl":num(st.get("gross_loss")),
+            "n":int(num(st.get("total_trades")))})
+        # derive gross P/L if absent: reconstruct from PF+PnL
+        if groups[-1]["gp"]==0 and num(st.get("profit_factor"))>0 and groups[-1]["pnl"]!=0:
+            pf=num(st.get("profit_factor")); pnl=groups[-1]["pnl"]
+            gl=pnl/(pf-1) if pf!=1 else 0.0
+            groups[-1]["gl"]=abs(gl); groups[-1]["gp"]=abs(gl)*pf
+        print(f"  g{i+1} {groups[-1]['span']}: n={groups[-1]['n']} PnL=${groups[-1]['pnl']:.0f}")
+    combos=[]
+    for a,b in itertools.combinations(range(6),2):
+        pnl=groups[a]["pnl"]+groups[b]["pnl"]; n=groups[a]["n"]+groups[b]["n"]
+        gp=groups[a]["gp"]+groups[b]["gp"]; gl=groups[a]["gl"]+groups[b]["gl"]
+        combos.append({"combo":f"g{a+1}+g{b+1}","pnl":round(pnl),"n":n,
+                       "pf":round(gp/gl,2) if gl>0 else None})
+    combos.sort(key=lambda c:c["pnl"])
+    pos=sum(1 for c in combos if c["pnl"]>0)
+    pfs=[c["pf"] for c in combos if c["pf"]]
+    med_pf=sorted(pfs)[len(pfs)//2] if pfs else None
+    print(f"\n{'combo':<10}{'pnl':>9}{'pf':>7}{'n':>6}")
+    for c in combos: print(f"{c['combo']:<10}{c['pnl']:>9}{str(c['pf']):>7}{c['n']:>6}")
+    worst=combos[0]["pnl"]
+    verdict=(pos>=10 and (med_pf or 0)>=1.2 and worst>-8000)
+    print(f"\npositive combos: {pos}/15 | median PF: {med_pf} | worst: ${worst}")
+    print(f"CPCV VERDICT: {'PASS' if verdict else 'FAIL'} (need >=10/15 pos, med PF>=1.2, worst>-$8K)")
+    (OUT/"cpcv_summary.json").write_text(json.dumps({"groups":groups,"combos":combos,
+        "positive":pos,"median_pf":med_pf,"worst":worst,"pass":verdict},indent=2))
+
+if __name__=="__main__": main()


### PR DESCRIPTION
CPCV (k=6, C(6,2)=15 combinations) on standalone wick_trap_v14rq: **15/15 combinations positive, median PF 1.41, worst alternate history +$2,421** (pre-registered bar: 10/15, PF 1.2, > -$8K). The edge is not era-luck. Every offline validation gate is now cleared; remaining evidence is live. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a validation report for the standalone Wick Trap configuration, covering 15 of 15 evaluation combinations, performance metrics, limitations, and related evidence.
  * Added a knowledge-base note summarizing the validated result, live-evidence status, alternate-history observations, and satellite strategy behavior.

* **New Features**
  * Added an evaluation utility that produces combination-level results, summary metrics, pass/fail status, and a machine-readable report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->