### PR TITLE
fix(live): paper account never blocks entries on margin

### DIFF
--- a/bin/live/v11_shadow_runner.py
+++ b/bin/live/v11_shadow_runner.py
@@ -1614,8 +1614,16 @@ class V11ShadowRunner:
         margin_cost = margin + commission + slippage
 
         if margin_cost > self.cash:
-            self.signals_rejected += 1
-            return
+            # PAPER ACCOUNT: never block a signal on margin (user directive
+            # 2026-07-10, after a valid wick_trap signal was silently crowded
+            # out by open junk-book positions). Cash may go negative — this is
+            # unlimited paper margin; PnL accounting is unaffected. Loud log so
+            # capital pressure remains visible.
+            logger.warning(
+                "[PAPER_MARGIN] %s %s needs $%.0f margin but only $%.0f cash free "
+                "— allowing anyway (paper account, cash goes negative)",
+                direction, archetype, margin_cost, self.cash,
+            )
 
         fill_price = entry_price * (1 + self.slippage_bps / 10000.0) if direction == 'long' \
             else entry_price * (1 - self.slippage_bps / 10000.0)


### PR DESCRIPTION
The July-6 wick_trap signal (first since the unlock) was silently killed by insufficient free margin — junk-book positions held the capital, `_open_position` returned with no log, and the upstream '>>> ENTRY' line printed anyway. Paper is paper: margin no longer blocks (cash may go negative, loud [PAPER_MARGIN] warning). Ironically the missed trade would have LOST ~$1.6K — but selective silent blocking corrupts the experiment either way. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paper trading positions can now open when margin requirements exceed the available cash balance.
  * Signals are no longer rejected solely because of insufficient simulated cash; the account balance may become negative to reflect the position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->