### PR TITLE
feat: unified strategy — level infra built, wick_trap confirmed as the unified strategy

### DIFF
--- a/bin/live/live_feature_computer.py
+++ b/bin/live/live_feature_computer.py
@@ -835,6 +835,16 @@ class LiveFeatureComputer:
         # R. RSI divergence (price vs RSI direction over 14-bar lookback)
         features['rsi_divergence'] = self._compute_rsi_divergence()
 
+        # S. Level-awareness features (2026-07-13, unified-strategy build):
+        # prior-day/week levels, confirmed swings + touch counts, sweep/reclaim
+        # events, acceptance counter, day_type. Single shared implementation
+        # with the batch store path (engine/features/level_features.py) —
+        # backtest/live parity by construction. Additive: fails soft to absent.
+        try:
+            features.update(self._compute_level_features())
+        except Exception as exc:
+            logger.warning("Level features failed: %s", exc)
+
         # D. Regime detection (MOVED AFTER Q: needs rv_20d, drawdown_persistence, etc.)
         # Probabilistic: crisis_prob, risk_temperature, instability_score
         # regime_label derived from CMI components (not SMA crossovers)
@@ -2618,6 +2628,21 @@ class LiveFeatureComputer:
     # ------------------------------------------------------------------
     # Private: FVG Detection
     # ------------------------------------------------------------------
+
+    def _compute_level_features(self) -> Dict[str, float]:
+        """Compute level-awareness features on the current buffer via the SAME
+        vectorized module the batch store uses (parity by construction). The
+        buffer tail is sufficient: all level features need only trailing data.
+        """
+        from engine.features.level_features import compute_level_features
+        if self._buf is None or len(self._buf) < 60:
+            return {}
+        buf = self._buf[['open', 'high', 'low', 'close', 'volume']].copy()
+        if getattr(buf.index, 'tz', None) is not None:
+            buf.index = buf.index.tz_localize(None)
+        lf = compute_level_features(buf)
+        row = lf.iloc[-1]
+        return {k: (float(v) if v == v else float('nan')) for k, v in row.items()}
 
     def _compute_rsi_divergence(self, lookback: int = 14) -> float:
         """

--- a/configs/champion/archetypes_unified/MIGRATION.md
+++ b/configs/champion/archetypes_unified/MIGRATION.md
@@ -1,0 +1,569 @@
+# Migration Guide: JSON to YAML Archetype Configs
+
+**Date:** 2026-02-04
+**Purpose:** Guide for migrating from monolithic JSON to isolated YAML configs
+
+## Overview
+
+This guide helps you migrate from:
+- **Old:** Monolithic `bull_machine_production_v10.json` with shared fusion weights
+- **New:** Isolated YAML files per archetype with per-archetype fusion weights
+
+## Why Migrate?
+
+### Problems with Monolithic JSON
+1. **Shared Fusion Weights:** All archetypes forced to use same fusion weights
+2. **Conflicting Optimizations:** Optimizing one archetype affects all others
+3. **Poor Version Control:** Hard to track changes per archetype
+4. **No A/B Testing:** Can't test archetype variations easily
+5. **Large Merge Conflicts:** Changes to any archetype affect entire file
+
+### Benefits of Isolated YAML
+1. **Per-Archetype Fusion:** Each archetype optimizes its own fusion weights
+2. **Independent Optimization:** Change one archetype without affecting others
+3. **Clear Git History:** See exactly what changed per archetype
+4. **Easy A/B Testing:** Copy YAML file and modify
+5. **Better Organization:** One file per archetype, easy to navigate
+
+## Migration Steps
+
+### Step 1: Understand Current Structure
+
+**Old Config (bull_machine_production_v10.json):**
+```json
+{
+  "version": "v10_extended_holds",
+  "archetypes": {
+    "use_archetypes": true,
+    "enable_A": true,
+    "enable_B": true,
+    "thresholds": {
+      "spring": {
+        "fusion_threshold": 0.18,
+        "pti_score_threshold": 0.05,
+        "disp_atr_multiplier": 0.2,
+        "wick_lower_threshold": 0.2
+      },
+      "order_block_retest": {
+        "fusion_threshold": 0.18,
+        "boms_strength_min": 0.1,
+        "wyckoff_min": 0.15
+      }
+    }
+  },
+  "fusion": {
+    "weights": {
+      "wyckoff": 0.5,
+      "liquidity": 0.2,
+      "momentum": 0.2,
+      "smc": 0.1
+    }
+  }
+}
+```
+
+**Problem:** Single fusion weights for all archetypes!
+
+### Step 2: Extract Archetype Configs
+
+For each archetype, create a YAML file with:
+1. Thresholds from `archetypes.thresholds.<name>`
+2. Fusion weights (initially estimated based on archetype type)
+3. Exit logic (if custom, otherwise use defaults)
+4. Position sizing (use defaults)
+5. Regime preferences (estimate based on archetype behavior)
+
+**Example: Spring (A)**
+
+```yaml
+# configs/archetypes/spring.yaml
+name: spring
+display_name: "Spring / UTAD"
+aliases: ["A", "trap_reversal", "wyckoff_spring_utad"]
+direction: long
+
+# NEW: Per-archetype fusion weights
+# Spring is Wyckoff-heavy, so give it high Wyckoff weight
+fusion_weights:
+  wyckoff: 0.60      # High for Wyckoff detection
+  liquidity: 0.20    # Medium for sweep component
+  momentum: 0.10     # Low
+  smc: 0.10         # Low
+
+# Thresholds from old config
+thresholds:
+  fusion_threshold: 0.18
+  pti_score_threshold: 0.05
+  disp_atr_multiplier: 0.2
+  wick_lower_threshold: 0.2
+
+# Exit logic (use defaults)
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels: [1.0, 2.0, 3.0]
+  scale_out_pcts: [0.3, 0.4, 0.3]
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+
+# Position sizing (use defaults)
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.5
+
+# Regime preferences (estimate)
+regime_preferences:
+  risk_on: 0.5       # Works but not optimal
+  neutral: 1.0       # Good
+  risk_off: 1.5      # Better
+  crisis: 2.0        # Best (counter-trend)
+
+allowed_regimes: []  # All regimes
+
+description: "PTI-based spring/UTAD detection"
+priority: 1
+enabled: true
+```
+
+### Step 3: Initial Fusion Weight Estimates
+
+Use these guidelines for initial fusion weights (will be optimized later):
+
+#### Wyckoff-Heavy Archetypes (0.50-0.70)
+```yaml
+# Spring (A), Trap Within Trend (H), Confluence Breakout (M)
+fusion_weights:
+  wyckoff: 0.60
+  liquidity: 0.20
+  momentum: 0.10
+  smc: 0.10
+```
+
+#### Liquidity-Heavy Archetypes (0.40-0.50)
+```yaml
+# Liquidity Vacuum (S1), Liquidity Compression (E), Funding Divergence (S4)
+# Long Squeeze (S5), Liquidity Sweep (G), Wick Trap (K)
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.45
+  momentum: 0.15
+  smc: 0.15
+```
+
+#### Momentum-Heavy Archetypes (0.35-0.45)
+```yaml
+# Exhaustion Reversal (F), Volume Fade Chop (S8), Failed Continuation (D)
+fusion_weights:
+  wyckoff: 0.20
+  liquidity: 0.20
+  momentum: 0.45
+  smc: 0.15
+```
+
+#### SMC-Heavy Archetypes (0.35-0.40)
+```yaml
+# Order Block Retest (B), FVG Continuation (C)
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.20
+  momentum: 0.15
+  smc: 0.40
+```
+
+#### Balanced Archetypes (0.25-0.30)
+```yaml
+# Retest Cluster (L), Whipsaw (S3)
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.30
+  momentum: 0.25
+  smc: 0.20
+```
+
+### Step 4: Convert Old Enable Flags
+
+**Old:**
+```json
+{
+  "archetypes": {
+    "enable_A": true,
+    "enable_B": true,
+    "enable_C": false,
+    "enable_S1": true
+  }
+}
+```
+
+**New:**
+Set `enabled: true/false` in each YAML file:
+
+```yaml
+# spring.yaml
+enabled: true
+
+# fvg_continuation.yaml
+enabled: false
+```
+
+### Step 5: Load and Test
+
+```python
+from engine.config.archetype_config_loader import load_archetype_configs
+
+# Load new YAML configs
+configs = load_archetype_configs("configs/archetypes/")
+
+# Validate
+for name, config in configs.items():
+    print(f"{name}: {config['fusion_weights']}")
+```
+
+### Step 6: Validate Schema
+
+```bash
+python engine/config/archetype_config_loader.py \
+  --dir configs/archetypes/ \
+  --verbose
+```
+
+Expected output:
+```
+Loading 16 archetype configs from configs/archetypes/
+Loaded spring (Spring / UTAD) - Fusion: W=0.60 L=0.20 M=0.10 S=0.10
+Loaded order_block_retest (Order Block Retest) - Fusion: W=0.30 L=0.15 M=0.15 S=0.40
+...
+Successfully loaded 16 archetype configs
+
+spring               | W=0.60 L=0.20 M=0.10 S=0.10 | long    | ENABLED
+order_block_retest   | W=0.30 L=0.15 M=0.15 S=0.40 | long    | ENABLED
+...
+
+All configs valid ✓
+```
+
+## Code Integration
+
+### Option 1: Backward Compatible (Recommended for Gradual Migration)
+
+Keep existing code working while adding new functionality:
+
+```python
+from engine.config.archetype_config_loader import (
+    load_archetype_configs,
+    merge_with_base_config
+)
+import json
+
+# Load old JSON config
+with open("configs/bull_machine_production_v10.json") as f:
+    base_config = json.load(f)
+
+# Load new YAML configs
+archetype_configs = load_archetype_configs("configs/archetypes/")
+
+# Merge (YAML takes precedence)
+merged_config = merge_with_base_config(archetype_configs, base_config)
+
+# Use merged config with existing code
+strategy = BullMachineStrategy(merged_config)
+```
+
+### Option 2: Direct YAML Loading (Recommended for New Code)
+
+Use YAML configs directly:
+
+```python
+from engine.config.archetype_config_loader import load_archetype_configs
+
+configs = load_archetype_configs("configs/archetypes/")
+
+# Use per-archetype fusion weights
+for archetype_name in configs:
+    config = configs[archetype_name]
+
+    if not config["enabled"]:
+        continue
+
+    # Get archetype-specific fusion weights
+    fusion_weights = config["fusion_weights"]
+
+    # Calculate fusion score with archetype-specific weights
+    fusion_score = calculate_fusion(
+        wyckoff_score * fusion_weights["wyckoff"] +
+        liquidity_score * fusion_weights["liquidity"] +
+        momentum_score * fusion_weights["momentum"] +
+        smc_score * fusion_weights["smc"]
+    )
+```
+
+## Fusion System Integration
+
+### Old Fusion (Global Weights)
+
+```python
+# engine/fusion/fusion_engine.py (OLD)
+class FusionEngine:
+    def __init__(self, config):
+        # Global weights for all archetypes
+        self.weights = config["fusion"]["weights"]
+
+    def calculate_fusion(self, domain_scores):
+        return (
+            domain_scores["wyckoff"] * self.weights["wyckoff"] +
+            domain_scores["liquidity"] * self.weights["liquidity"] +
+            domain_scores["momentum"] * self.weights["momentum"] +
+            domain_scores["smc"] * self.weights["smc"]
+        )
+```
+
+### New Fusion (Per-Archetype Weights)
+
+```python
+# engine/fusion/fusion_engine.py (NEW)
+from engine.config.archetype_config_loader import load_archetype_configs
+
+class FusionEngine:
+    def __init__(self, config_dir="configs/archetypes/"):
+        # Load per-archetype weights
+        self.archetype_configs = load_archetype_configs(config_dir)
+
+    def calculate_fusion(self, archetype_name, domain_scores):
+        # Get archetype-specific weights
+        weights = self.archetype_configs[archetype_name]["fusion_weights"]
+
+        # Calculate fusion with archetype weights
+        return (
+            domain_scores["wyckoff"] * weights["wyckoff"] +
+            domain_scores["liquidity"] * weights["liquidity"] +
+            domain_scores["momentum"] * weights["momentum"] +
+            domain_scores["smc"] * weights["smc"]
+        )
+```
+
+## Testing Migration
+
+### 1. Validate Config Loading
+
+```python
+import pytest
+from engine.config.archetype_config_loader import load_archetype_configs
+
+def test_load_configs():
+    configs = load_archetype_configs("configs/archetypes/")
+
+    # Check all 16 archetypes loaded
+    assert len(configs) == 16
+
+    # Check spring loaded correctly
+    assert "spring" in configs
+    spring = configs["spring"]
+
+    # Check fusion weights sum to 1.0
+    weight_sum = sum(spring["fusion_weights"].values())
+    assert 0.99 <= weight_sum <= 1.01
+
+    # Check required fields
+    assert "name" in spring
+    assert "thresholds" in spring
+    assert "fusion_weights" in spring
+```
+
+### 2. Compare Fusion Scores
+
+```python
+def test_fusion_parity():
+    """Test that new fusion matches old fusion when using global weights."""
+
+    # Load old config
+    with open("configs/bull_machine_production_v10.json") as f:
+        old_config = json.load(f)
+    old_weights = old_config["fusion"]["weights"]
+
+    # Load new config
+    new_configs = load_archetype_configs("configs/archetypes/")
+
+    # Test fusion calculation
+    domain_scores = {
+        "wyckoff": 0.5,
+        "liquidity": 0.3,
+        "momentum": 0.6,
+        "smc": 0.4
+    }
+
+    # Old fusion (global weights)
+    old_fusion = (
+        domain_scores["wyckoff"] * old_weights["wyckoff"] +
+        domain_scores["liquidity"] * old_weights["liquidity"] +
+        domain_scores["momentum"] * old_weights["momentum"] +
+        domain_scores["smc"] * old_weights["smc"]
+    )
+
+    # New fusion (per-archetype weights)
+    spring_weights = new_configs["spring"]["fusion_weights"]
+    new_fusion = (
+        domain_scores["wyckoff"] * spring_weights["wyckoff"] +
+        domain_scores["liquidity"] * spring_weights["liquidity"] +
+        domain_scores["momentum"] * spring_weights["momentum"] +
+        domain_scores["smc"] * spring_weights["smc"]
+    )
+
+    # Should be different (that's the point!)
+    assert old_fusion != new_fusion
+
+    # But both should be valid
+    assert 0.0 <= old_fusion <= 1.0
+    assert 0.0 <= new_fusion <= 1.0
+```
+
+### 3. Backtest Comparison
+
+```bash
+# Run backtest with old config
+python bin/nautilus_backtest.py \
+  --config configs/bull_machine_production_v10.json \
+  --start 2023-01-01 \
+  --end 2023-12-31 \
+  --output results/old_config.json
+
+# Run backtest with new YAML configs
+python bin/nautilus_backtest.py \
+  --config-dir configs/archetypes/ \
+  --start 2023-01-01 \
+  --end 2023-12-31 \
+  --output results/new_config.json
+
+# Compare results
+python bin/compare_backtest_results.py \
+  --old results/old_config.json \
+  --new results/new_config.json
+```
+
+## Rollback Plan
+
+If migration causes issues:
+
+### 1. Keep Old Config Working
+Don't delete `bull_machine_production_v10.json` immediately.
+
+### 2. Feature Flag
+```python
+USE_YAML_CONFIGS = os.getenv("USE_YAML_CONFIGS", "false").lower() == "true"
+
+if USE_YAML_CONFIGS:
+    configs = load_archetype_configs("configs/archetypes/")
+else:
+    with open("configs/bull_machine_production_v10.json") as f:
+        configs = json.load(f)
+```
+
+### 3. Gradual Rollout
+Migrate one archetype at a time:
+
+```python
+# Hybrid approach: Use YAML for some archetypes, JSON for others
+yaml_archetypes = ["spring", "order_block_retest"]
+yaml_configs = load_archetype_configs("configs/archetypes/")
+
+for archetype in yaml_archetypes:
+    # Use YAML config
+    config = yaml_configs[archetype]
+else:
+    # Use old JSON config
+    config = old_json_config["archetypes"]["thresholds"][archetype]
+```
+
+## Post-Migration Optimization
+
+After migration, optimize each archetype independently:
+
+```bash
+# Optimize spring with new per-archetype fusion weights
+python bin/optimize_archetype.py \
+  --archetype spring \
+  --optimize-fusion-weights \
+  --metric sharpe \
+  --n-trials 100
+
+# Results saved to: configs/archetypes/spring_optimized.yaml
+```
+
+## Common Issues
+
+### Issue 1: Fusion Weights Don't Sum to 1.0
+
+**Error:**
+```
+WARNING: Fusion weights for spring sum to 0.95, expected ~1.0. Normalizing...
+```
+
+**Fix:**
+Adjust weights in YAML file:
+```yaml
+fusion_weights:
+  wyckoff: 0.60
+  liquidity: 0.20
+  momentum: 0.10
+  smc: 0.10  # Sum = 1.00 ✓
+```
+
+### Issue 2: Missing Required Field
+
+**Error:**
+```
+ValueError: Missing required field 'direction' in configs/archetypes/spring.yaml
+```
+
+**Fix:**
+Add required field:
+```yaml
+direction: long
+```
+
+### Issue 3: Invalid Regime Name
+
+**Error:**
+```
+ValueError: Invalid regime 'bull_market' in configs/archetypes/spring.yaml
+```
+
+**Fix:**
+Use valid regime names:
+```yaml
+allowed_regimes: [risk_on, neutral, risk_off, crisis]
+```
+
+## Checklist
+
+- [ ] Extract all archetype thresholds from JSON
+- [ ] Create YAML files for all 16 archetypes
+- [ ] Assign initial fusion weights per archetype
+- [ ] Add exit logic to each archetype
+- [ ] Add regime preferences
+- [ ] Validate all configs with loader tool
+- [ ] Update code to load YAML configs
+- [ ] Run comparison backtests
+- [ ] Document changes in git
+- [ ] Optimize fusion weights per archetype
+- [ ] Archive old JSON config
+
+## Timeline
+
+**Week 1:** Extract and create YAML files
+**Week 2:** Integrate with code, test backward compatibility
+**Week 3:** Run validation backtests
+**Week 4:** Optimize per-archetype fusion weights
+**Week 5:** Full production rollout
+
+## Support
+
+For issues or questions:
+1. Check **SCHEMA.md** for config format
+2. Check **README.md** for usage examples
+3. Run validation: `python engine/config/archetype_config_loader.py`
+4. Check logs for detailed error messages
+
+---
+
+**Created:** 2026-02-04
+**Version:** 1.0

--- a/configs/champion/archetypes_unified/README.md
+++ b/configs/champion/archetypes_unified/README.md
@@ -1,0 +1,370 @@
+# Archetype Configuration System
+
+**Version:** 1.0
+**Date:** 2026-02-04
+**Status:** Production Ready
+
+## Overview
+
+This directory contains isolated YAML configuration files for all 16 Bull Machine archetypes. Each archetype has its own config file for independent optimization and version control.
+
+## Key Innovation: Per-Archetype Fusion Weights
+
+The primary improvement over the monolithic JSON config is **per-archetype fusion weights**. This allows each archetype to optimize its own fusion calculation independently.
+
+### Before (Monolithic)
+```json
+{
+  "fusion": {
+    "weights": {
+      "wyckoff": 0.5,
+      "liquidity": 0.2,
+      "momentum": 0.2,
+      "smc": 0.1
+    }
+  }
+}
+```
+**Problem:** All archetypes forced to use same fusion weights
+
+### After (Isolated)
+```yaml
+# spring.yaml
+fusion_weights:
+  wyckoff: 0.60    # Spring is Wyckoff-heavy
+  liquidity: 0.20
+  momentum: 0.10
+  smc: 0.10
+
+# liquidity_vacuum.yaml
+fusion_weights:
+  wyckoff: 0.35
+  liquidity: 0.45  # Liquidity Vacuum is liquidity-heavy
+  momentum: 0.10
+  smc: 0.10
+```
+**Benefit:** Each archetype optimized for its core detection strategy
+
+## Directory Contents
+
+### Core Files
+- **16 YAML Configs:** One per archetype (A, B, C, D, E, F, G, H, K, L, M, S1, S3, S4, S5, S8)
+- **SCHEMA.md:** Complete schema documentation
+- **README.md:** This file
+- **MIGRATION.md:** Migration guide from JSON
+
+### Legacy Files
+- **production/**: Old JSON configs (deprecated, kept for reference)
+- **spring_utad_baseline.json**: Old baseline configs (deprecated)
+
+## Quick Start
+
+### 1. Load Configs
+
+```python
+from engine.config.archetype_config_loader import load_archetype_configs
+
+# Load all archetype configs
+configs = load_archetype_configs("configs/archetypes/")
+
+# Get specific archetype
+spring = configs["spring"]
+print(f"Fusion weights: {spring['fusion_weights']}")
+print(f"Thresholds: {spring['thresholds']}")
+```
+
+### 2. Get Fusion Weights
+
+```python
+from engine.config.archetype_config_loader import get_archetype_fusion_weights
+
+# Get fusion weights for spring archetype
+weights = get_archetype_fusion_weights("spring")
+# Returns: {'wyckoff': 0.6, 'liquidity': 0.2, 'momentum': 0.1, 'smc': 0.1}
+```
+
+### 3. Get Enabled Archetypes
+
+```python
+from engine.config.archetype_config_loader import get_enabled_archetypes
+
+enabled = get_enabled_archetypes()
+# Returns: ['spring', 'order_block_retest', 'fvg_continuation', ...]
+```
+
+### 4. Validate Configs
+
+```bash
+python engine/config/archetype_config_loader.py --dir configs/archetypes/ --verbose
+```
+
+## Archetype Summary
+
+| Code | Name | File | Direction | Primary Domain |
+|------|------|------|-----------|----------------|
+| A | Spring | `spring.yaml` | long | Wyckoff (0.60) |
+| B | Order Block Retest | `order_block_retest.yaml` | long | SMC (0.40) |
+| C | FVG Continuation | `fvg_continuation.yaml` | long | SMC (0.35) |
+| D | Failed Continuation | `failed_continuation.yaml` | long | Momentum (0.35) |
+| E | Liquidity Compression | `liquidity_compression.yaml` | long | Liquidity (0.50) |
+| F | Exhaustion Reversal | `exhaustion_reversal.yaml` | long | Momentum (0.45) |
+| G | Liquidity Sweep | `liquidity_sweep.yaml` | long | Liquidity (0.40) |
+| H | Trap Within Trend | `trap_within_trend.yaml` | long | Wyckoff/Liquidity (0.35/0.35) |
+| K | Wick Trap | `wick_trap.yaml` | long | Liquidity (0.40) |
+| L | Retest Cluster | `retest_cluster.yaml` | long | Liquidity (0.30) |
+| M | Confluence Breakout | `confluence_breakout.yaml` | long | Wyckoff (0.30) |
+| S1 | Liquidity Vacuum | `liquidity_vacuum.yaml` | long | Liquidity (0.45) |
+| S3 | Whipsaw | `whipsaw.yaml` | neutral | Liquidity/Momentum (0.30/0.30) |
+| S4 | Funding Divergence | `funding_divergence.yaml` | long | Liquidity (0.50) |
+| S5 | Long Squeeze | `long_squeeze.yaml` | short | Liquidity (0.50) |
+| S8 | Volume Fade Chop | `volume_fade_chop.yaml` | neutral | Momentum (0.40) |
+
+## Configuration Philosophy
+
+### Fusion Weight Guidelines
+
+**Wyckoff-Heavy Archetypes (0.50-0.70):**
+- Spring (A): 0.60
+- Trap Within Trend (H): 0.35
+- Confluence Breakout (M): 0.30
+
+**Liquidity-Heavy Archetypes (0.40-0.50):**
+- Liquidity Vacuum (S1): 0.45
+- Liquidity Compression (E): 0.50
+- Funding Divergence (S4): 0.50
+- Long Squeeze (S5): 0.50
+- Liquidity Sweep (G): 0.40
+- Wick Trap (K): 0.40
+
+**Momentum-Heavy Archetypes (0.35-0.45):**
+- Exhaustion Reversal (F): 0.45
+- Volume Fade Chop (S8): 0.40
+- Failed Continuation (D): 0.35
+
+**SMC-Heavy Archetypes (0.35-0.40):**
+- Order Block Retest (B): 0.40
+- FVG Continuation (C): 0.35
+
+**Balanced Archetypes (0.25-0.30):**
+- Retest Cluster (L): All ~0.25-0.30
+- Whipsaw (S3): All ~0.25-0.30
+
+### Threshold Ranges
+
+**Conservative (Low Frequency):**
+- Fusion threshold: 0.35-0.45
+- Examples: M (0.18), L (0.18)
+
+**Balanced (Medium Frequency):**
+- Fusion threshold: 0.25-0.35
+- Examples: A-H (0.18)
+
+**Aggressive (High Frequency):**
+- Fusion threshold: 0.15-0.25
+- Examples: S1, S4, S5 (0.15)
+
+## Optimization Workflow
+
+### 1. Individual Archetype Optimization
+
+```bash
+# Optimize spring archetype only
+python bin/optimize_archetype.py \
+  --archetype spring \
+  --metric sharpe \
+  --n-trials 100
+
+# Writes optimized params to: configs/archetypes/spring_optimized.yaml
+```
+
+### 2. A/B Testing
+
+```bash
+# Create variant
+cp configs/archetypes/spring.yaml configs/archetypes/spring_v2.yaml
+
+# Edit spring_v2.yaml with experimental weights
+vim configs/archetypes/spring_v2.yaml
+
+# Compare
+python bin/compare_archetype_configs.py \
+  --config-a configs/archetypes/spring.yaml \
+  --config-b configs/archetypes/spring_v2.yaml
+```
+
+### 3. Batch Optimization
+
+```bash
+# Optimize all archetypes
+for archetype in A B C D E F G H K L M S1 S3 S4 S5 S8; do
+  python bin/optimize_archetype.py --archetype $archetype
+done
+```
+
+## Integration with Existing Code
+
+### Backward Compatibility
+
+The config loader provides `merge_with_base_config()` to maintain compatibility:
+
+```python
+from engine.config.archetype_config_loader import (
+    load_archetype_configs,
+    merge_with_base_config
+)
+
+# Load YAML configs
+archetype_configs = load_archetype_configs("configs/archetypes/")
+
+# Load base JSON config
+import json
+with open("configs/bull_machine_production_v10.json") as f:
+    base_config = json.load(f)
+
+# Merge for backward compatibility
+merged_config = merge_with_base_config(archetype_configs, base_config)
+
+# Use merged config with existing code
+strategy = BullMachineStrategy(merged_config)
+```
+
+### New Code (Recommended)
+
+```python
+from engine.config.archetype_config_loader import load_archetype_configs
+
+# Load configs directly
+configs = load_archetype_configs("configs/archetypes/")
+
+# Use per-archetype fusion weights
+for archetype_name in configs:
+    fusion_weights = configs[archetype_name]["fusion_weights"]
+    fusion_score = calculate_archetype_fusion(
+        archetype_name,
+        fusion_weights,
+        domain_scores
+    )
+```
+
+## File Format
+
+All configs use YAML for human readability and git-friendliness.
+
+### Example Config
+
+```yaml
+# Archetype A - Spring / UTAD
+name: spring
+display_name: "Spring / UTAD"
+aliases: ["A", "trap_reversal", "wyckoff_spring_utad"]
+direction: long
+
+# Per-archetype fusion weights
+fusion_weights:
+  wyckoff: 0.60
+  liquidity: 0.20
+  momentum: 0.10
+  smc: 0.10
+
+# Entry thresholds
+thresholds:
+  fusion_threshold: 0.18
+  pti_score_threshold: 0.05
+  disp_atr_multiplier: 0.2
+  wick_lower_threshold: 0.2
+
+# Exit logic
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels: [1.0, 2.0, 3.0]
+  scale_out_pcts: [0.3, 0.4, 0.3]
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+
+# Position sizing
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.5
+
+# Regime preferences
+regime_preferences:
+  risk_on: 0.5
+  neutral: 1.0
+  risk_off: 1.5
+  crisis: 2.0
+
+# Allowed regimes
+allowed_regimes: []  # All regimes
+
+# Metadata
+description: "PTI-based spring/UTAD detection"
+priority: 1
+enabled: true
+```
+
+## Next Steps
+
+### 1. Integration Tasks
+- [ ] Update `engine/archetypes/logic_v2_adapter.py` to use per-archetype fusion weights
+- [ ] Update `engine/fusion/fusion_engine.py` to support archetype-specific weights
+- [ ] Update backtesting framework to load YAML configs
+- [ ] Add archetype config versioning (v1, v2, etc.)
+
+### 2. Optimization Tasks
+- [ ] Run Optuna optimization for each archetype independently
+- [ ] Validate optimized configs on out-of-sample data
+- [ ] Document optimal fusion weight ranges per archetype type
+- [ ] Create archetype performance comparison dashboard
+
+### 3. Testing Tasks
+- [ ] Unit tests for config loader
+- [ ] Integration tests for merged configs
+- [ ] Validation tests for schema compliance
+- [ ] Performance tests (YAML vs JSON loading)
+
+## Benefits Summary
+
+### 1. Isolation
+Each archetype can be optimized independently without affecting others.
+
+### 2. Clarity
+Clear ownership of config parameters per archetype.
+
+### 3. Version Control
+Git-friendly YAML format with clear diff history per archetype.
+
+### 4. A/B Testing
+Easy to create archetype variants for experimentation.
+
+### 5. Optimization
+Per-archetype fusion weights unlock independent optimization.
+
+### 6. Documentation
+Self-documenting configs with inline comments.
+
+### 7. Flexibility
+Easy to disable/enable archetypes or create new ones.
+
+## See Also
+
+- **SCHEMA.md** - Complete configuration schema
+- **MIGRATION.md** - Migration guide from JSON
+- **production/README_PRODUCTION_CONFIGS.md** - Legacy JSON configs
+- **engine/config/archetype_config_loader.py** - Config loader implementation
+- **engine/archetypes/registry.py** - Archetype registry
+
+## Questions?
+
+For questions or issues:
+1. Check **SCHEMA.md** for config format
+2. Check **MIGRATION.md** for migration help
+3. Run validation tool: `python engine/config/archetype_config_loader.py`
+4. Check logs for config loading errors
+
+---
+
+**Created:** 2026-02-04
+**Author:** Bull Machine Team
+**Version:** 1.0

--- a/configs/champion/archetypes_unified/SCHEMA.md
+++ b/configs/champion/archetypes_unified/SCHEMA.md
@@ -1,0 +1,467 @@
+# Archetype Configuration Schema
+
+**Version:** 1.0
+**Date:** 2026-02-04
+**Purpose:** Define schema for isolated archetype YAML configs
+
+## Overview
+
+Each archetype has its own YAML file in `configs/archetypes/` for:
+- **Isolation**: Independent optimization without affecting other archetypes
+- **Clarity**: Clear configuration ownership per archetype
+- **Versioning**: Easy to track changes per archetype in git
+- **A/B Testing**: Simple to create archetype variations
+
+## Directory Structure
+
+```
+configs/archetypes/
+├── spring.yaml                    # Archetype A
+├── order_block_retest.yaml        # Archetype B
+├── fvg_continuation.yaml          # Archetype C
+├── failed_continuation.yaml       # Archetype D
+├── liquidity_compression.yaml     # Archetype E
+├── exhaustion_reversal.yaml       # Archetype F
+├── liquidity_sweep.yaml           # Archetype G
+├── trap_within_trend.yaml         # Archetype H
+├── wick_trap.yaml                 # Archetype K
+├── retest_cluster.yaml            # Archetype L
+├── confluence_breakout.yaml       # Archetype M
+├── liquidity_vacuum.yaml          # Archetype S1
+├── whipsaw.yaml                   # Archetype S3
+├── funding_divergence.yaml        # Archetype S4
+├── long_squeeze.yaml              # Archetype S5
+├── volume_fade_chop.yaml          # Archetype S8
+└── production/                    # Legacy JSON configs (deprecated)
+```
+
+## Schema Definition
+
+### Required Fields
+
+```yaml
+# Core Identity
+name: string                       # Canonical name (snake_case)
+display_name: string               # Human-readable name
+direction: "long" | "short" | "neutral"
+
+# Entry Thresholds
+thresholds:
+  fusion_threshold: float          # Minimum fusion score (0.0-1.0)
+  # ... archetype-specific thresholds
+```
+
+### Optional Fields (with defaults)
+
+```yaml
+# Aliases for backward compatibility
+aliases: [string, ...]             # ["A", "spring", ...]
+
+# NEW: Per-archetype fusion weights
+fusion_weights:
+  wyckoff: float                   # Default: 0.25 (sum must = 1.0)
+  liquidity: float                 # Default: 0.25
+  momentum: float                  # Default: 0.25
+  smc: float                       # Default: 0.25
+
+# Exit Logic
+exit_logic:
+  max_hold_hours: int              # Default: 168 (7 days)
+  scale_out_enabled: bool          # Default: true
+  scale_out_levels: [float, ...]   # R-multiples [1.0, 2.0, 3.0]
+  scale_out_pcts: [float, ...]     # Portions [0.3, 0.4, 0.3]
+  trailing_start_r: float          # Default: 1.0
+  trailing_atr_mult: float         # Default: 2.0
+
+# Position Sizing
+position_sizing:
+  risk_per_trade_pct: float        # Default: 0.02 (2%)
+  max_position_size_pct: float     # Default: 0.1 (10%)
+  atr_stop_mult: float             # Default: 2.5
+
+# Regime Preferences (multipliers)
+regime_preferences:
+  risk_on: float                   # Default: 1.0 (neutral)
+  neutral: float                   # Default: 1.0
+  risk_off: float                  # Default: 1.0
+  crisis: float                    # Default: 1.0
+
+# Regime Filtering
+allowed_regimes: [string, ...]     # Default: [] (all allowed)
+                                   # Options: ["risk_on", "neutral", "risk_off", "crisis"]
+
+# Metadata
+description: string                # Default: ""
+priority: int                      # Default: 100 (lower = higher priority)
+enabled: bool                      # Default: true
+```
+
+## Field Details
+
+### 1. Core Identity
+
+#### `name` (required)
+- **Type:** string
+- **Format:** snake_case
+- **Purpose:** Canonical identifier for code
+- **Example:** `"spring"`, `"order_block_retest"`
+
+#### `display_name` (required)
+- **Type:** string
+- **Purpose:** Human-readable name for UI/logs
+- **Example:** `"Spring / UTAD"`, `"Order Block Retest"`
+
+#### `direction` (required)
+- **Type:** enum
+- **Values:** `"long"`, `"short"`, `"neutral"`
+- **Purpose:** Trade direction bias
+- **Note:** Only `"long_squeeze"` is currently `"short"`
+
+#### `aliases`
+- **Type:** list of strings
+- **Purpose:** Backward compatibility with legacy letter codes
+- **Example:** `["A", "spring", "wyckoff_spring_utad"]`
+
+### 2. Fusion Weights (NEW - Key Innovation)
+
+```yaml
+fusion_weights:
+  wyckoff: 0.60        # Primary domain
+  liquidity: 0.20      # Secondary
+  momentum: 0.10       # Tertiary
+  smc: 0.10           # Supporting
+```
+
+**Purpose:** Per-archetype fusion calculation for independent optimization
+
+**Guidelines:**
+- **Sum must equal 1.0** (will auto-normalize if not)
+- Higher weight = more influence on fusion score
+- Reflects archetype's core detection strategy
+
+**Domain Weight Ranges by Archetype Type:**
+
+| Archetype Type | Primary Domain | Typical Weights |
+|----------------|----------------|-----------------|
+| Wyckoff (A, H) | wyckoff | 0.50-0.70 |
+| Liquidity (S1, S4, G, K) | liquidity | 0.40-0.50 |
+| Momentum (F, D) | momentum | 0.40-0.50 |
+| SMC (B, C, M) | smc | 0.35-0.50 |
+| Balanced (L, E) | mixed | 0.25-0.35 each |
+
+### 3. Entry Thresholds
+
+```yaml
+thresholds:
+  fusion_threshold: 0.18           # Universal threshold
+  # Archetype-specific thresholds below:
+  pti_score_threshold: 0.05        # Example: Spring
+  boms_strength_min: 0.1           # Example: Order Block
+  smc_score_min: 0.15              # Example: FVG
+  # ... etc
+```
+
+**Common Thresholds:**
+- `fusion_threshold`: Minimum fusion score (0.15-0.40 typical)
+- `liquidity_score_min`: Minimum liquidity score
+- `wyckoff_min`: Minimum Wyckoff score
+- `momentum_min`: Minimum momentum score
+- `smc_score_min`: Minimum SMC score
+
+**Archetype-Specific:**
+Each archetype has unique thresholds. See individual YAML files.
+
+### 4. Exit Logic
+
+```yaml
+exit_logic:
+  max_hold_hours: 168              # Maximum hold time
+  scale_out_enabled: true          # Enable scale-out
+  scale_out_levels: [1.0, 2.0, 3.0]   # R-multiples to scale
+  scale_out_pcts: [0.3, 0.4, 0.3]     # % to exit at each level
+  trailing_start_r: 1.0            # Start trailing at 1R
+  trailing_atr_mult: 2.0           # Trail with 2x ATR
+```
+
+**Scale-Out Example:**
+- At 1.0R profit: Exit 30% of position
+- At 2.0R profit: Exit 40% of remaining (28% total)
+- At 3.0R profit: Exit 30% of remaining (12.6% total)
+- Remaining 29.4% rides with trailing stop
+
+### 5. Position Sizing
+
+```yaml
+position_sizing:
+  risk_per_trade_pct: 0.02         # 2% risk per trade
+  max_position_size_pct: 0.1       # Max 10% of portfolio
+  atr_stop_mult: 2.5               # Stop at 2.5x ATR
+```
+
+**Risk Calculation:**
+```
+position_size = (account_equity * risk_per_trade_pct) / (atr * atr_stop_mult)
+position_size = min(position_size, account_equity * max_position_size_pct)
+```
+
+### 6. Regime Preferences
+
+```yaml
+regime_preferences:
+  risk_on: 1.3       # 30% boost in risk-on
+  neutral: 1.0       # No change in neutral
+  risk_off: 0.7      # 30% penalty in risk-off
+  crisis: 0.5        # 50% penalty in crisis
+```
+
+**Purpose:** Weight multipliers for regime routing
+
+**Example:**
+- Base fusion score: 0.40
+- In risk_on: 0.40 * 1.3 = 0.52 (boosted)
+- In crisis: 0.40 * 0.5 = 0.20 (penalized)
+
+**Typical Patterns:**
+- **Bull archetypes (A-M):** High in risk_on, low in crisis
+- **Bear archetypes (S1, S3, S4):** High in crisis/risk_off, low in risk_on
+- **Neutral archetypes (S3, S8):** High in neutral, low in trending
+
+### 7. Allowed Regimes
+
+```yaml
+allowed_regimes: [risk_on, neutral]  # Only fire in these regimes
+# OR
+allowed_regimes: []                  # Fire in all regimes
+```
+
+**Purpose:** Hard filter - archetype won't fire outside allowed regimes
+
+**Common Patterns:**
+- Bull archetypes: `[risk_on, neutral]`
+- Bear archetypes: `[risk_off, crisis]`
+- Universal: `[]` (all allowed)
+
+## Example: Complete Config
+
+```yaml
+# Archetype A - Spring / UTAD
+name: spring
+display_name: "Spring / UTAD"
+aliases: ["A", "trap_reversal", "wyckoff_spring_utad"]
+direction: long
+
+# Per-archetype fusion weights
+fusion_weights:
+  wyckoff: 0.60        # Primary: Wyckoff spring detection
+  liquidity: 0.20      # Secondary: Liquidity sweep component
+  momentum: 0.10       # Tertiary: Momentum reversal
+  smc: 0.10           # Supporting: SMC structure
+
+# Entry thresholds
+thresholds:
+  fusion_threshold: 0.18
+  pti_score_threshold: 0.05
+  disp_atr_multiplier: 0.2
+  wick_lower_threshold: 0.2
+
+# Exit logic
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels: [1.0, 2.0, 3.0]
+  scale_out_pcts: [0.3, 0.4, 0.3]
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+
+# Position sizing
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.5
+
+# Regime preferences
+regime_preferences:
+  risk_on: 0.5       # Works but not optimal
+  neutral: 1.0       # Good
+  risk_off: 1.5      # Better
+  crisis: 2.0        # Best (counter-trend)
+
+# Allowed regimes
+allowed_regimes: []  # Works in all regimes
+
+# Metadata
+description: "PTI-based spring/UTAD detection with displacement confirmation"
+priority: 1
+enabled: true
+```
+
+## Loading Configs
+
+### Python API
+
+```python
+from engine.config.archetype_config_loader import (
+    load_archetype_configs,
+    get_archetype_fusion_weights,
+    get_enabled_archetypes
+)
+
+# Load all configs
+configs = load_archetype_configs("configs/archetypes/")
+
+# Get specific archetype
+spring = configs["spring"]
+fusion_weights = spring["fusion_weights"]
+
+# Get fusion weights only
+weights = get_archetype_fusion_weights("spring")
+
+# Get enabled archetypes
+enabled = get_enabled_archetypes()
+```
+
+### CLI Validation
+
+```bash
+python engine/config/archetype_config_loader.py \
+  --dir configs/archetypes/ \
+  --verbose
+```
+
+## Migration from JSON
+
+### Old (Monolithic JSON)
+
+```json
+{
+  "archetypes": {
+    "thresholds": {
+      "spring": {
+        "fusion_threshold": 0.18,
+        "pti_score_threshold": 0.05
+      }
+    }
+  },
+  "fusion": {
+    "weights": {
+      "wyckoff": 0.5,
+      "liquidity": 0.2,
+      "momentum": 0.2,
+      "smc": 0.1
+    }
+  }
+}
+```
+
+**Problem:** Single fusion weights for all archetypes
+
+### New (Isolated YAML)
+
+```yaml
+# configs/archetypes/spring.yaml
+name: spring
+fusion_weights:
+  wyckoff: 0.60
+  liquidity: 0.20
+  momentum: 0.10
+  smc: 0.10
+thresholds:
+  fusion_threshold: 0.18
+  pti_score_threshold: 0.05
+```
+
+**Benefit:** Per-archetype fusion optimization
+
+## Optimization Workflow
+
+### 1. Independent Optimization
+
+```bash
+# Optimize spring archetype only
+python bin/optimize_archetype.py --archetype spring
+
+# Results: configs/archetypes/spring_optimized.yaml
+```
+
+### 2. A/B Testing
+
+```bash
+# Create variant
+cp configs/archetypes/spring.yaml configs/archetypes/spring_v2.yaml
+
+# Edit spring_v2.yaml with different weights
+# Compare performance
+```
+
+### 3. Version Control
+
+```bash
+git diff configs/archetypes/spring.yaml
+# Shows only changes to spring archetype
+```
+
+## Best Practices
+
+### 1. Fusion Weight Selection
+
+**Start with archetype domain focus:**
+- Wyckoff archetypes: `wyckoff: 0.5-0.7`
+- Liquidity archetypes: `liquidity: 0.4-0.6`
+- Momentum archetypes: `momentum: 0.4-0.6`
+- SMC archetypes: `smc: 0.4-0.6`
+
+**Then optimize with Optuna/grid search**
+
+### 2. Threshold Tuning
+
+**Conservative (low frequency):**
+- `fusion_threshold: 0.35-0.45`
+- Higher quality, fewer trades
+
+**Balanced:**
+- `fusion_threshold: 0.25-0.35`
+- Medium frequency
+
+**Aggressive (high frequency):**
+- `fusion_threshold: 0.15-0.25`
+- More trades, lower average quality
+
+### 3. Regime Configuration
+
+**Risk-on specialists (A-M):**
+```yaml
+regime_preferences:
+  risk_on: 1.3
+  neutral: 1.0
+  risk_off: 0.7
+  crisis: 0.5
+allowed_regimes: [risk_on, neutral]
+```
+
+**Crisis specialists (S1, S3):**
+```yaml
+regime_preferences:
+  risk_on: 0.5
+  neutral: 0.8
+  risk_off: 1.5
+  crisis: 2.5
+allowed_regimes: [risk_off, crisis]
+```
+
+## Validation Checklist
+
+- [ ] All required fields present
+- [ ] Fusion weights sum to 1.0
+- [ ] Direction is valid (long/short/neutral)
+- [ ] Thresholds are reasonable (0.0-1.0 for scores)
+- [ ] Exit logic percentages sum to 1.0
+- [ ] Regime preferences are positive floats
+- [ ] Allowed regimes are valid
+- [ ] No syntax errors (run validation tool)
+
+## See Also
+
+- `/configs/archetypes/*.yaml` - Individual archetype configs
+- `/engine/config/archetype_config_loader.py` - Config loader
+- `/configs/archetypes/production/README_PRODUCTION_CONFIGS.md` - Legacy configs
+- `/engine/archetypes/registry.py` - Archetype registry

--- a/configs/champion/archetypes_unified/bos_choch_reversal_baseline.json
+++ b/configs/champion/archetypes_unified/bos_choch_reversal_baseline.json
@@ -1,0 +1,30 @@
+{
+  "archetype": "bos_choch_reversal",
+  "description": "BOS/CHOCH Reversal (C) - Break of structure / change of character",
+  "direction": "long",
+  "enabled": true,
+  "thresholds": {
+    "min_adx": 18,
+    "min_rsi": 45,
+    "max_rsi": 80,
+    "min_volume_zscore": 0.8,
+    "min_fusion_score": 0.35,
+    "require_htf_alignment": true,
+    "smc_weight": 0.40,
+    "momentum_weight": 0.30,
+    "volume_weight": 0.20,
+    "regime_weight": 0.10
+  },
+  "allowed_regimes": ["risk_on", "neutral"],
+  "risk_management": {
+    "atr_stop_mult": 2.0,
+    "max_risk_pct": 0.02,
+    "take_profit_r": 3.5
+  },
+  "notes": [
+    "Baseline config with permissive thresholds for discovery",
+    "Optimized for bullish break of structure detection",
+    "Primary signal: tf1h_bos_bullish or tf4h_bos_bullish",
+    "Domain engines: SMC (40%), Momentum (30%), Volume (20%)"
+  ]
+}

--- a/configs/champion/archetypes_unified/confluence_breakout.yaml
+++ b/configs/champion/archetypes_unified/confluence_breakout.yaml
@@ -1,0 +1,77 @@
+name: confluence_breakout
+display_name: Confluence Breakout / Ratio Coil Break
+aliases:
+- M
+- coil
+- wyckoff_insider
+- ratio_coil_break
+direction: long
+fusion_weights:
+  wyckoff: 0.35
+  liquidity: 0.3
+  momentum: 0.25
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.12
+  min_coil_score: 0.25
+  require_breakout_flag: false
+  atr_pctile: 0.4
+  poc_dist: 1.0
+  boms_strength: 0.0
+  fusion: 0.12
+  cooling_period_bars: 24
+hard_gates:
+- feature: atr_percentile
+  op: max
+  value: 0.4
+  nan_policy: skip
+  description: Low volatility coil
+- feature: tf4h_fusion_score
+  op: min
+  value: 0.2
+  nan_policy: skip
+  description: MTF confluence confirmation
+- feature: volume_zscore
+  op: min
+  value: 0.5
+  nan_policy: fail
+  description: Breakouts need volume confirmation
+- feature: derived:distribution_at_resistance
+  op: bool_false
+  nan_policy: skip
+  description: Block longs at resistance in 4H distribution (Wyckoff phase context)
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 96
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.25
+  - 0.25
+  - 0.4
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.3
+  atr_tp_mult: 4.7
+regime_preferences:
+  risk_on: 1.3
+  neutral: 1.0
+  risk_off: 0.7
+  crisis: 0.5
+allowed_regimes: []
+description: Low ATR + near POC + BOMS strength. High-quality coil breakout pattern.
+priority: 11
+enabled: true
+bypass_fusion_threshold: true
+# Path A opt-out — CB's hard_gates are known mis-calibrated (volume_zscore min 0.5
+# filters OUT winners; Lesson #54 territory). Keep bypass behavior until gates
+# are recalibrated to match what CB winners actually look like.
+enforce_gates_under_bypass: false

--- a/configs/champion/archetypes_unified/exhaustion_reversal.yaml
+++ b/configs/champion/archetypes_unified/exhaustion_reversal.yaml
@@ -1,0 +1,64 @@
+name: exhaustion_reversal
+display_name: Exhaustion Reversal
+aliases:
+- F
+- expansion_exhaustion
+direction: long
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.2
+  momentum: 0.45
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.18
+  rsi_max: 65.0
+  rsi_ext: 65.0
+  volume_z_min: 0.3
+  vol_z: 0.3
+  atr_percentile_min: 0.5
+  atr_pctile: 0.5
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: derived:rsi_extreme_65
+  op: bool_true
+  description: RSI must be extreme
+- feature: atr_percentile
+  op: min
+  value: 0.5
+  nan_policy: skip
+  description: High volatility
+- feature: volume_zscore
+  op: min
+  value: 0.3
+  description: Volume elevated
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 48
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 1.5
+  scale_out_pcts:
+  - 0.3
+  - 0.4
+  - 0.3
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.2
+  atr_tp_mult: 5.0
+regime_preferences:
+  risk_on: 0.9
+  neutral: 1.0
+  risk_off: 1.3
+  crisis: 1.5
+allowed_regimes: []
+description: Extreme RSI + high ATR + volume spike. Momentum exhaustion reversal.
+priority: 9
+enabled: true

--- a/configs/champion/archetypes_unified/failed_continuation.yaml
+++ b/configs/champion/archetypes_unified/failed_continuation.yaml
@@ -1,0 +1,73 @@
+name: failed_continuation
+display_name: Failed Continuation
+aliases:
+- D
+- failed_fvg
+direction: long
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.25
+  momentum: 0.35
+  smc: 0.15
+thresholds:
+  fusion_threshold: 0.18
+  rsi_min: 55.0
+  rsi_max: 55.0
+  momentum_min: 0.1
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: derived:any_fvg
+  op: bool_true
+  nan_policy: skip
+  description: FVG must be present
+- feature: rsi_14
+  op: max
+  value: 55
+  description: RSI must be weak
+- feature: volume_zscore
+  op: max
+  value: 3.5
+  nan_policy: fail
+  description: Volume fading (failed continuation needs declining volume)
+- feature: effort_result_ratio
+  op: max
+  value: 1.4
+  nan_policy: skip
+  description: Low effort-to-result confirms failing move
+- feature: chop_score
+  op: max
+  value: 0.25
+  nan_policy: skip
+  description: Low chop required - failed continuations in choppy markets stop out
+    (backtest PF 1.94->2.51)
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 96
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 1.5
+  scale_out_pcts:
+  - 0.25
+  - 0.35
+  - 0.3
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.0
+  atr_tp_mult: 5.8
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.8
+  crisis: 0.6
+allowed_regimes: []
+description: FVG present + weak RSI + falling ADX. Failed bearish continuation reversal.
+priority: 8
+enabled: true

--- a/configs/champion/archetypes_unified/funding_divergence.yaml
+++ b/configs/champion/archetypes_unified/funding_divergence.yaml
@@ -1,0 +1,79 @@
+name: funding_divergence
+display_name: Funding Divergence (Short Squeeze)
+aliases:
+- S4
+- distribution
+direction: long
+fusion_weights:
+  wyckoff: 0.2
+  liquidity: 0.5
+  momentum: 0.2
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.15
+  funding_z_max: -0.5
+  funding_z_min: 0.5
+  resilience_min: 0.25
+  liquidity_max: 0.65
+  vol_climax: 0.8
+  liq_max: 0.65
+  fusion: 0.15
+  cooling_period_bars: 24
+hard_gates:
+- feature: funding_Z
+  op: max
+  value: -0.5
+  nan_policy: skip
+  description: Negative funding (real data since 2020)
+- feature: funding_oi_divergence
+  op: eq
+  value: 1
+  nan_policy: skip
+  description: Bullish divergence (shorts building = more squeeze fuel)
+- feature: ls_ratio_extreme
+  op: max
+  value: -0.5
+  nan_policy: skip
+  description: Shorts relatively crowded
+- feature: oi_price_divergence
+  op: min
+  value: 0.01
+  nan_policy: skip
+  description: OI declining while price holds (squeeze fuel)
+- feature: oi_change_4h
+  op: max
+  value: 0.05
+  nan_policy: skip
+  description: OI should be dropping in funding divergence
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 240
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  - 3.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.10
+  runner_trailing_atr: 3.5
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.1
+  atr_tp_mult: 4.5
+regime_preferences:
+  risk_on: 0.8
+  neutral: 1.2
+  risk_off: 1.0
+  crisis: 0.7
+allowed_regimes: []
+description: Negative funding + resilience. Short squeeze setup from funding divergence.
+priority: 14
+enabled: true

--- a/configs/champion/archetypes_unified/fvg_continuation.yaml
+++ b/configs/champion/archetypes_unified/fvg_continuation.yaml
@@ -1,0 +1,61 @@
+name: fvg_continuation
+display_name: FVG Continuation / BOS-CHOCH
+aliases:
+- C
+- bos
+- choch
+- bos_choch_reversal
+direction: long
+fusion_weights:
+  wyckoff: 0.15
+  liquidity: 0.2
+  momentum: 0.3
+  smc: 0.35
+thresholds:
+  fusion_threshold: 0.18
+  smc_score_min: 0.15
+  momentum_min: 0.1
+  disp_atr: 0.0
+  momentum: 0.1
+  tf4h_fusion: 0.15
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: derived:any_bos_any_tf
+  op: bool_true
+  nan_policy: fail
+  description: BOS on 1H or 4H
+- feature: derived:any_fvg
+  op: bool_true
+  nan_policy: fail
+  description: FVG present
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 72
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.3
+  - 0.3
+  - 0.3
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 1.2
+  atr_tp_mult: 5.2
+regime_preferences:
+  risk_on: 1.3
+  neutral: 1.0
+  risk_off: 0.7
+  crisis: 0.5
+allowed_regimes: []
+description: Displacement + momentum + recent BOS. High-quality breakout continuation.
+priority: 3
+enabled: true

--- a/configs/champion/archetypes_unified/liquidity_compression.yaml
+++ b/configs/champion/archetypes_unified/liquidity_compression.yaml
@@ -1,0 +1,71 @@
+name: liquidity_compression
+display_name: Liquidity Compression
+aliases:
+- E
+- compression
+direction: long
+fusion_weights:
+  wyckoff: 0.2
+  liquidity: 0.5
+  momentum: 0.15
+  smc: 0.15
+thresholds:
+  fusion_threshold: 0.18
+  liquidity_min: 0.25
+  liquidity_max: 0.7
+  liquidity_score_min: 0.25
+  liquidity_imbalance_max: 6.0
+  atr_pctile: 0.35
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: volume_zscore
+  op: min
+  value: 1.5
+  nan_policy: skip
+  description: Elevated volume confirms exhaustion (not quiet market)
+- feature: derived:rsi_extreme_65
+  op: bool_true
+  nan_policy: skip
+  description: RSI at extreme confirms exhaustion reversal potential
+- feature: bb_width
+  op: max
+  value: 0.06
+  nan_policy: skip
+  description: Compression before expansion (BB squeeze)
+- feature: chop_score
+  op: max
+  value: 0.50
+  nan_policy: skip
+  description: Avoid mid-chop dead zone (0.5-0.7 = PF 0.93 historically)
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 120
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.3
+  - 0.4
+  runner_pct: 0.10
+  runner_trailing_atr: 2.5
+  trailing_start_r: 0.5
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.7
+  atr_tp_mult: 5.2
+regime_preferences:
+  risk_on: 1.1
+  neutral: 1.2
+  risk_off: 0.9
+  crisis: 0.7
+allowed_regimes: []
+description: "Volume exhaustion \u2014 climax volume at RSI extremes after compression.\
+  \ Institutional capitulation signal."
+priority: 10
+enabled: true

--- a/configs/champion/archetypes_unified/liquidity_sweep.yaml
+++ b/configs/champion/archetypes_unified/liquidity_sweep.yaml
@@ -1,0 +1,65 @@
+name: liquidity_sweep
+display_name: Liquidity Sweep & Reclaim
+aliases:
+- G
+- sweep
+- liquidity_sweep_reclaim
+direction: long
+fusion_weights:
+  wyckoff: 0.3
+  liquidity: 0.4
+  momentum: 0.15
+  smc: 0.15
+thresholds:
+  fusion_threshold: 0.18
+  wyckoff_phase: B
+  boms_strength_min: 0.0
+  boms_strength: 0.0
+  liq: 0.2
+  fusion: 0.18
+  volume_cluster: true
+  cooling_period_bars: 24
+hard_gates:
+- feature: liquidity_score
+  op: min
+  value: 0.35
+  nan_policy: fail
+  description: "Meaningful liquidity floor (raised from 0.20 \u2014 PF 3.04\u2192\
+    3.26)"
+- feature: wick_lower_ratio
+  op: min
+  value: 0.5
+  nan_policy: fail
+  description: 'Sweep direction validation (lower wick > body for long sweep) [FIXED
+    2026-07-13: 1.3 assumed wick/body scale; feature is wick/range (bounded <=1).
+    intent "wick>body" ~= 0.5 of range]'
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.15
+  runner_trailing_atr: 2.5
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.0
+  atr_tp_mult: 4.4
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.9
+  crisis: 0.8
+allowed_regimes: []
+description: BOMS strength + rising liquidity from oversold. Liquidity grab reversal.
+priority: 7
+enabled: true

--- a/configs/champion/archetypes_unified/liquidity_sweep.yaml.gated
+++ b/configs/champion/archetypes_unified/liquidity_sweep.yaml.gated
@@ -1,0 +1,66 @@
+name: liquidity_sweep
+display_name: Liquidity Sweep & Reclaim
+aliases:
+- G
+- sweep
+- liquidity_sweep_reclaim
+direction: long
+fusion_weights:
+  wyckoff: 0.3
+  liquidity: 0.4
+  momentum: 0.15
+  smc: 0.15
+thresholds:
+  fusion_threshold: 0.18
+  wyckoff_phase: B
+  boms_strength_min: 0.0
+  boms_strength: 0.0
+  liq: 0.2
+  fusion: 0.18
+  volume_cluster: true
+  cooling_period_bars: 24
+hard_gates:
+- feature: liquidity_score
+  op: min
+  value: 0.2
+  description: Minimum liquidity for sweep
+- feature: wick_lower_ratio
+  op: min
+  value: 1.3
+  nan_policy: fail
+  description: Sweep direction validation (lower wick > body for long sweep)
+- feature: derived:prior_12h_return
+  op: max
+  value: 0.05
+  nan_policy: skip
+  description: Post-rally exhaustion filter — sweeps after >5% rally have neg EV (empirical, 4334-bar study)
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.15
+  runner_trailing_atr: 2.5
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.0
+  atr_tp_mult: 4.4
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.9
+  crisis: 0.8
+allowed_regimes: []
+description: BOMS strength + rising liquidity from oversold. Liquidity grab reversal.
+priority: 7
+enabled: true

--- a/configs/champion/archetypes_unified/liquidity_sweep_baseline.json
+++ b/configs/champion/archetypes_unified/liquidity_sweep_baseline.json
@@ -1,0 +1,31 @@
+{
+  "archetype": "liquidity_sweep",
+  "description": "Liquidity Sweep (G) - Institutional stop hunt reversals",
+  "direction": "long",
+  "enabled": true,
+  "thresholds": {
+    "min_wick_lower_ratio": 0.30,
+    "min_volume_zscore": 1.2,
+    "min_recovery_body": 0.25,
+    "min_fusion_score": 0.35,
+    "max_rsi_chase": 75,
+    "smc_weight": 0.35,
+    "price_action_weight": 0.30,
+    "volume_weight": 0.20,
+    "wyckoff_weight": 0.10,
+    "regime_weight": 0.05
+  },
+  "allowed_regimes": ["risk_on", "neutral", "risk_off"],
+  "risk_management": {
+    "atr_stop_mult": 2.5,
+    "max_risk_pct": 0.02,
+    "take_profit_r": 3.0
+  },
+  "notes": [
+    "Baseline config with permissive thresholds for discovery",
+    "Optimized for liquidity sweep reversal detection",
+    "Primary signal: smc_liquidity_sweep + deep lower wick",
+    "Domain engines: SMC (35%), Price Action (30%), Volume (20%)",
+    "Works in risk_off regime during capitulation events"
+  ]
+}

--- a/configs/champion/archetypes_unified/liquidity_vacuum.yaml
+++ b/configs/champion/archetypes_unified/liquidity_vacuum.yaml
@@ -1,0 +1,67 @@
+name: liquidity_vacuum
+display_name: Liquidity Vacuum Reversal
+aliases:
+- S1
+- breakdown
+- capitulation
+direction: long
+fusion_weights:
+  wyckoff: 0.35
+  liquidity: 0.45
+  momentum: 0.1
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.15
+  liquidity_score_min: 0.15
+  wyckoff_confidence_min: 0.25
+  volume_spike_threshold: 0.25
+  crisis_threshold: 0.03
+  liq_max: 0.3
+  vol_z: 0.8
+  fusion: 0.15
+  cooling_period_bars: 36
+hard_gates:
+- feature: liquidity_score
+  op: max
+  value: 0.45
+  description: Low liquidity (capitulation) -- 0.30 was too strict (16.8% of bars)
+- feature: volume_zscore
+  op: min
+  value: 0.0
+  description: Above-median volume activity
+- feature: wick_exhaustion_last_3b
+  op: min
+  value: 0.47
+  nan_policy: skip
+  description: 'Wick exhaustion validates vacuum (94% pass - mild veto) [FIXED 2026-07-13:
+    1.4 was sum-scale; feature is mean of 3 wick fractions (bounded <1). 1.4/3=0.47]'
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 120
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.15
+  runner_trailing_atr: 3.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.4
+  atr_tp_mult: 5.5
+regime_preferences:
+  risk_on: 0.5
+  neutral: 0.8
+  risk_off: 1.5
+  crisis: 2.5
+allowed_regimes: []
+description: Crisis capitulation reversal. Liquidity vacuum at panic lows.
+priority: 12
+enabled: true

--- a/configs/champion/archetypes_unified/long_squeeze.yaml
+++ b/configs/champion/archetypes_unified/long_squeeze.yaml
@@ -1,0 +1,79 @@
+name: long_squeeze
+display_name: Long Squeeze Cascade
+aliases:
+- S5
+direction: short
+fusion_weights:
+  wyckoff: 0.2
+  liquidity: 0.5
+  momentum: 0.2
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.15
+  funding_z_min: 0.5
+  rsi_min: 50.0
+  liquidity_max: 0.6
+  funding_max: 0.0
+  oi_min: 0.0
+  vol_min: 0.5
+  fusion: 0.15
+  cooling_period_bars: 24
+hard_gates:
+- feature: funding_Z
+  op: min
+  value: 0.5
+  nan_policy: skip
+  description: Positive funding (real data since 2020)
+- feature: rsi_14
+  op: min
+  value: 60.0
+  description: RSI elevated (squeeze needs overcrowded longs, was 50 = useless)
+- feature: ls_ratio_extreme
+  op: min
+  value: 1.5
+  nan_policy: skip
+  description: Longs extremely overcrowded
+- feature: funding_oi_divergence
+  op: eq
+  value: -1
+  nan_policy: skip
+  description: Bearish (funding bullish but OI declining = smart longs exiting)
+- feature: vol_shock
+  op: max
+  value: 0.10
+  nan_policy: skip
+  description: No acute vol spike - all 3 historical losses had vol_shock >0.10, all 11 winners had vol_shock <0.10 (LOW CONFIDENCE n=14)
+- feature: derived:accumulation_at_support
+  op: bool_false
+  nan_policy: skip
+  description: Block shorts at support in 4H accumulation (Wyckoff phase context)
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 72
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 1.5
+  scale_out_pcts:
+  - 0.3
+  - 0.3
+  - 0.3
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 1.3
+  atr_tp_mult: 6.0
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.7
+  crisis: 0.5
+allowed_regimes: []
+description: Positive funding extreme + overheating. Long squeeze cascade (SHORT archetype).
+priority: 15
+enabled: true

--- a/configs/champion/archetypes_unified/oi_divergence.yaml
+++ b/configs/champion/archetypes_unified/oi_divergence.yaml
@@ -1,0 +1,141 @@
+# OI Divergence Reversal
+#
+# Detects "hollow" price moves where Open Interest is declining despite price
+# making new local extremes. When price pushes to a new high/low but OI drops,
+# it means existing positions are being CLOSED (smart money exiting) rather than
+# new positions being opened. The move lacks conviction and is likely to reverse.
+#
+# REQUIRES: Binance Futures API features in the feature store:
+#   - oi_change_4h        : 4-hour Open Interest % change
+#   - oi_change_24h       : 24-hour Open Interest % change
+#   - oi_price_divergence : Composite OI-vs-price divergence score
+#   - binance_funding_rate: Current Binance perpetual funding rate
+#   - ls_ratio_extreme    : Long/Short ratio extreme flag
+#   - taker_imbalance     : Net taker buy/sell imbalance
+#
+# These features are NaN/0 before ~2020 and in any backtest run without
+# Binance Futures data. All hard gates use nan_policy: skip and
+# frozen_bypass: true so the archetype gracefully degrades when data is
+# unavailable (gates are skipped, fusion score alone decides).
+#
+# This archetype is GENUINELY DIFFERENT from all 16 existing archetypes:
+#   - Only archetype that uses Open Interest data
+#   - Detects positioning-based divergences (not price structure)
+#   - Contrarian signal based on institutional flow
+
+name: oi_divergence
+display_name: "OI Divergence Reversal"
+aliases:
+- S9
+- oi_div
+- open_interest_divergence
+direction: long
+
+# Per-archetype fusion weights
+# Primary: liquidity (0.45) -- OI is a liquidity/positioning metric
+# Secondary: momentum (0.30) -- RSI/price extreme confirmation
+# Tertiary: wyckoff (0.15) -- accumulation/distribution context
+# Supporting: smc (0.10) -- order flow structure
+fusion_weights:
+  wyckoff: 0.15
+  liquidity: 0.45
+  momentum: 0.30
+  smc: 0.10
+
+# Entry thresholds
+thresholds:
+  fusion_threshold: 0.15
+  oi_decline_4h: -0.02
+  oi_decline_24h: -0.03
+  rsi_oversold: 35.0
+  rsi_overbought: 65.0
+  volume_z_min: 0.0
+  funding_rate_threshold: 0.0001
+  price_extreme_lookback: 24
+  price_extreme_percentile: 0.90
+  fusion: 0.15
+  cooling_period_bars: 24
+
+# Hard gates -- ALL must pass before this archetype can fire
+# nan_policy: skip ensures gates are skipped when OI features are NaN (pre-2022)
+# OI features are REAL data since 2022 — no frozen_bypass needed
+hard_gates:
+- feature: oi_change_4h
+  op: max
+  value: -0.02
+  nan_policy: skip
+  description: "OI must be declining >2% over 4h (positions closing)"
+- feature: oi_change_24h
+  op: max
+  value: -0.03
+  nan_policy: skip
+  description: "OI must be declining >3% over 24h (sustained unwind)"
+- feature: volume_zscore
+  op: min
+  value: 0.0
+  description: "Volume must be above average (confirms activity)"
+- feature: rsi_14
+  op: max
+  value: 35.0
+  nan_policy: skip
+  description: "RSI oversold for long entry (contrarian)"
+- feature: taker_imbalance
+  op: max
+  value: 0.1
+  nan_policy: skip
+  description: "Net selling (taker flow confirms smart money exiting)"
+- feature: derived:distribution_at_resistance
+  op: bool_false
+  nan_policy: skip
+  description: "Block longs at resistance in 4H distribution (Wyckoff phase context)"
+gate_mode: soft
+
+# Exit logic
+exit_logic:
+  max_hold_hours: 48
+  scale_out_enabled: true
+  scale_out_levels:
+  - 1.0
+  - 1.5
+  - 2.5
+  scale_out_pcts:
+  - 0.30
+  - 0.40
+  - 0.30
+  runner_pct: 0.0
+  runner_trailing_atr: 0.0
+  trailing_start_r: 1.5
+  trailing_atr_mult: 2.0
+
+# Position sizing
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.0
+  atr_tp_mult: 3.5
+
+# Regime preferences
+# OI divergence is a CONTRARIAN signal, so it thrives in regimes
+# opposite to the signal direction:
+#   - In bull regime, OI divergence shorts (smart money exiting longs) are valuable
+#   - In bear regime, OI divergence longs (shorts unwinding) are valuable
+#   - In crisis, OI data from exchanges may be lagging or unreliable
+regime_preferences:
+  risk_on: 0.8
+  neutral: 1.0
+  risk_off: 1.3
+  crisis: 0.5
+
+# Allowed regimes -- empty means fire in all regimes
+allowed_regimes: []
+
+description: >
+  Open Interest divergence reversal. Price makes new extreme while OI
+  declines, signaling institutional position unwinding. Contrarian smart
+  money signal not derivable from price action alone. Requires Binance
+  Futures API features (oi_change_4h, oi_change_24h, oi_price_divergence,
+  binance_funding_rate). Features are NaN before ~2020; gates use
+  nan_policy: skip for graceful degradation.
+
+priority: 17
+enabled: true

--- a/configs/champion/archetypes_unified/order_block_retest.yaml
+++ b/configs/champion/archetypes_unified/order_block_retest.yaml
@@ -1,0 +1,61 @@
+name: order_block_retest
+display_name: Order Block Retest
+aliases:
+- B
+- OB
+- ob_retest
+direction: long
+fusion_weights:
+  wyckoff: 0.3
+  liquidity: 0.15
+  momentum: 0.15
+  smc: 0.4
+thresholds:
+  fusion_threshold: 0.18
+  boms_strength_min: 0.0
+  boms_strength: 0.0
+  wyckoff_min: 0.15
+  wyckoff: 0.15
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: derived:any_bos_1h
+  op: bool_true
+  nan_policy: skip
+  description: BOS structure
+- feature: fib_time_confluence
+  op: min
+  value: 0.1
+  nan_policy: skip
+  description: Fib time ratio confluence (lowered for better soft gate balance)
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 96
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.25
+  - 0.25
+  - 0.4
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 1.9
+  atr_tp_mult: 4.9
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.8
+  crisis: 0.6
+allowed_regimes: []
+description: BOMS strength + Wyckoff + near BOS zone. SMC order block continuation
+  pattern.
+priority: 2
+enabled: true

--- a/configs/champion/archetypes_unified/order_block_retest_baseline.json
+++ b/configs/champion/archetypes_unified/order_block_retest_baseline.json
@@ -1,0 +1,29 @@
+{
+  "archetype": "order_block_retest",
+  "description": "Order Block Retest (B) - SMC demand zone retests",
+  "direction": "long",
+  "enabled": true,
+  "thresholds": {
+    "max_distance_from_ob": 0.05,
+    "min_bounce_body": 0.30,
+    "min_fusion_score": 0.35,
+    "max_volume_spike_down": -1.5,
+    "smc_weight": 0.35,
+    "price_action_weight": 0.25,
+    "wyckoff_weight": 0.20,
+    "volume_weight": 0.15,
+    "regime_weight": 0.05
+  },
+  "allowed_regimes": ["risk_on", "neutral"],
+  "risk_management": {
+    "atr_stop_mult": 2.0,
+    "max_risk_pct": 0.02,
+    "take_profit_r": 2.5
+  },
+  "notes": [
+    "Baseline config with permissive thresholds for discovery",
+    "Optimized for SMC order block retest detection",
+    "Primary signal: price retesting bullish order block zone",
+    "Domain engines: SMC (35%), Price Action (25%), Wyckoff (20%)"
+  ]
+}

--- a/configs/champion/archetypes_unified/production/README_PRODUCTION_CONFIGS.md
+++ b/configs/champion/archetypes_unified/production/README_PRODUCTION_CONFIGS.md
@@ -1,0 +1,252 @@
+# Production Archetype Configurations
+
+**Created:** 2025-12-15
+**Purpose:** Production-ready configs for all 16 archetypes with proper thresholds
+**Location:** `/configs/archetypes/production/`
+
+## Overview
+
+This directory contains production-ready JSON configuration files for all 16 archetypes. These configs replace the smoke test configs (which had `thresholds=0` blocking all signals) with proper production thresholds designed to allow quality signals while maintaining selectivity.
+
+## Key Design Principles
+
+1. **Relaxed Thresholds**: `fusion_threshold` set to 0.22-0.40 (vs 0.0 in smoke tests) to allow signals
+2. **All 6 Engines Enabled**: Every config has all domain engines active for maximum boost
+3. **Regime-Aware Routing**: Weight multipliers vary by market regime for each archetype
+4. **Production Risk Management**: Appropriate `base_risk_pct`, `atr_stop_mult`, and `cooldown_bars`
+5. **Archetype-Specific Parameters**: Each config tailored to its detection strategy
+
+## Configuration Files (16 Total)
+
+### Bull Market Archetypes (11)
+
+| Code | Name | File | Direction | Fusion Threshold | Key Focus |
+|------|------|------|-----------|------------------|-----------|
+| A | Spring | `archetype_a_spring.json` | long | 0.35 | Wyckoff springs at accumulation |
+| B | Order Block Retest | `archetype_b_order_block_retest.json` | long | 0.30 | SMC order block continuations |
+| C | Wick Trap | `archetype_c_wick_trap.json` | long | 0.30 | Bullish wick rejections |
+| D | Failed Continuation | `archetype_d_failed_continuation.json` | long | 0.35 | Failed bearish pattern reversals |
+| E | Volume Exhaustion | `archetype_e_volume_exhaustion.json` | long | 0.35 | Selling climax reversals |
+| F | Exhaustion Reversal | `archetype_f_exhaustion_reversal.json` | long | 0.35 | Momentum exhaustion longs |
+| G | Liquidity Sweep | `archetype_g_liquidity_sweep.json` | long | 0.30 | Liquidity grab reversals |
+| H | Momentum Continuation | `archetype_h_momentum_continuation.json` | long | 0.28 | Uptrend pullback entries |
+| K | Trap Within Trend | `archetype_k_trap_within_trend.json` | long | 0.32 | False breakdown in uptrends |
+| L | Retest Cluster | `archetype_l_retest_cluster.json` | long | 0.38 | Multi-factor confluence zones |
+| M | Confluence Breakout | `archetype_m_confluence_breakout.json` | long | 0.40 | High-quality breakouts |
+
+### Bear Market Archetypes (3)
+
+| Code | Name | File | Direction | Fusion Threshold | Key Focus |
+|------|------|------|-----------|------------------|-----------|
+| S1 | Liquidity Vacuum | `archetype_s1_liquidity_vacuum.json` | long | 0.54 | Crisis capitulation reversals |
+| S4 | Funding Divergence | `archetype_s4_funding_divergence.json` | long | 0.78 | Negative funding + resilience |
+| S5 | Long Squeeze | `archetype_s5_long_squeeze.json` | short | 0.45 | Overheated long liquidations |
+
+### Neutral Archetypes (2)
+
+| Code | Name | File | Direction | Fusion Threshold | Key Focus |
+|------|------|------|-----------|------------------|-----------|
+| S3 | Whipsaw | `archetype_s3_whipsaw.json` | neutral | 0.25 | Range-bound mean reversion |
+| S8 | Volume Fade Chop | `archetype_s8_volume_fade_chop.json` | neutral | 0.22 | Low-volume fade trades |
+
+## Threshold Strategy by Archetype Type
+
+### Premium Quality (High Selectivity)
+- **S1, S4, M**: `fusion_threshold >= 0.40`
+- Low frequency, high quality
+- Strongest confluence requirements
+- Best for crisis/high-conviction setups
+
+### Standard Quality (Balanced)
+- **A, D, E, F, L**: `fusion_threshold = 0.35-0.38`
+- Medium frequency
+- Good balance of quality and quantity
+- Core reversal strategies
+
+### Active Trading (Higher Frequency)
+- **B, C, G, H, K**: `fusion_threshold = 0.28-0.32`
+- Higher trade frequency
+- Continuation and trap patterns
+- Better in trending markets
+
+### Scalping (Opportunistic)
+- **S3, S8**: `fusion_threshold = 0.22-0.25`
+- Highest frequency
+- Lower risk per trade
+- Neutral regime specialists
+
+## Domain Engine Configuration
+
+All 16 configs have identical engine settings:
+
+```json
+{
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true
+  }
+}
+```
+
+This ensures maximum signal boost from all 6 domain engines.
+
+## Regime Routing Examples
+
+### Bull Archetypes (A-M)
+- **Risk-On**: 1.0-2.0x weight (favored in bull markets)
+- **Neutral**: 1.0x weight (baseline)
+- **Risk-Off**: 0.5-0.8x weight (reduced)
+- **Crisis**: 0.2-0.5x weight (minimal)
+
+### Bear Archetypes (S1, S4, S5)
+- **Risk-On**: 0.0-0.5x weight (minimal/disabled)
+- **Neutral**: 0.5-1.0x weight (moderate)
+- **Risk-Off**: 1.0-2.2x weight (favored)
+- **Crisis**: 1.5-2.5x weight (maximum)
+
+### Neutral Archetypes (S3, S8)
+- **Risk-On**: 0.2-0.3x weight (minimal)
+- **Neutral**: 1.5-2.0x weight (maximum)
+- **Risk-Off**: 0.5-0.8x weight (moderate)
+- **Crisis**: 0.1x weight (disabled)
+
+## Risk Management
+
+### Conservative (Bear Archetypes)
+- `base_risk_pct`: 0.015 (1.5%)
+- `max_position_size_pct`: 0.15 (15%)
+- `atr_stop_mult`: 2.2-3.0
+
+### Standard (Bull Archetypes)
+- `base_risk_pct`: 0.02 (2%)
+- `max_position_size_pct`: 0.20 (20%)
+- `atr_stop_mult`: 1.8-2.5
+
+### Aggressive (Scalping)
+- `base_risk_pct`: 0.008-0.01 (0.8-1%)
+- `max_position_size_pct`: 0.10 (10%)
+- `atr_stop_mult`: 1.0-1.5
+
+## Usage Instructions
+
+### Single Archetype Backtest
+```bash
+python bin/backtest_knowledge_v2.py \
+  --config configs/archetypes/production/archetype_a_spring.json \
+  --pair BTCUSDT \
+  --timeframe 1h \
+  --start-date 2020-01-01 \
+  --end-date 2024-12-31
+```
+
+### Portfolio Backtest (Multiple Archetypes)
+Create a unified config with multiple archetypes enabled:
+```json
+{
+  "version": "portfolio_bull_v1",
+  "profile": "Bull Market Portfolio - All 11 Bull Archetypes",
+  "archetypes": {
+    "use_archetypes": true,
+    "enable_A": true,
+    "enable_B": true,
+    "enable_C": true,
+    ...
+  }
+}
+```
+
+### Quick Validation Test
+```bash
+# Test S1 on 2022 bear market
+python bin/backtest_knowledge_v2.py \
+  --config configs/archetypes/production/archetype_s1_liquidity_vacuum.json \
+  --pair BTCUSDT \
+  --timeframe 1h \
+  --start-date 2022-01-01 \
+  --end-date 2022-12-31
+```
+
+## Expected Behavior
+
+### High-Quality Archetypes
+- **S1**: 40-60 trades/year, 50-60% win rate
+- **S4**: 12 trades/year, PF 2.22, 55.7% win rate
+- **S5**: 9 trades/year, PF 1.86, 55.6% win rate
+- **M**: 8-15 trades/year, high win rate expected
+
+### Medium-Frequency Archetypes
+- **A, D, E, F, L**: 20-40 trades/year
+- **B, G, K**: 30-50 trades/year
+- **H**: 40-60 trades/year (trend follower)
+
+### Active Trading Archetypes
+- **C**: 50-80 trades/year (wick traps)
+- **S3**: 60-100 trades/year (range scalps)
+- **S8**: 80-120 trades/year (fade trades)
+
+## Validation Checklist
+
+Before deploying any config to live trading:
+
+- [ ] Run backtest on full 2020-2024 dataset
+- [ ] Verify trade count is reasonable (not 0, not excessive)
+- [ ] Check win rate is above 45%
+- [ ] Ensure profit factor > 1.2
+- [ ] Validate max drawdown < 30%
+- [ ] Test on out-of-sample period (2024 H2)
+- [ ] Review regime distribution of trades
+- [ ] Confirm no config parsing errors
+
+## Next Steps
+
+1. **Individual Testing**: Run each archetype individually to establish baselines
+2. **Regime Validation**: Test bear archetypes on 2022, bull on 2021, neutral on 2023
+3. **Portfolio Construction**: Combine non-correlated archetypes for portfolio effect
+4. **Optimization**: Run Optuna on promising archetypes to refine thresholds
+5. **Walk-Forward**: Validate on rolling windows to test stability
+
+## Troubleshooting
+
+### No Trades Generated
+- Check `fusion_threshold` - may be too high
+- Verify domain engines are enabled
+- Review regime routing weights
+- Ensure feature data is available
+
+### Too Many Trades
+- Increase `fusion_threshold`
+- Add `cooldown_bars`
+- Increase `min_confidence`
+- Tighten archetype-specific thresholds
+
+### Low Win Rate
+- Review false positives in trade log
+- Tighten detection criteria
+- Add confluence requirements
+- Review exit strategy
+
+## References
+
+**Template Configs:**
+- `/configs/variants/s1_full.json` - S1 production reference
+- `/configs/variants/s4_full.json` - S4 production reference
+- `/configs/variants/s5_full.json` - S5 production reference
+
+**Documentation:**
+- `ARCHETYPE_NAME_MAPPING_REFERENCE.md` - Archetype code reference
+- `ARCHETYPE_MODEL_IMPLEMENTATION.md` - Technical implementation
+- `docs/ARCHETYPE_SYSTEMS_PRODUCTION_GUIDE.md` - Production deployment
+
+**Optimization:**
+- `bin/optimize_archetype_regime_aware.py` - Single archetype optimization
+- `bin/optuna_parallel_archetypes_v2.py` - Multi-archetype parallel optimization
+
+---
+
+**Status:** Production Ready
+**Last Updated:** 2025-12-15
+**Maintainer:** Bull Machine Development Team

--- a/configs/champion/archetypes_unified/production/archetype_a_spring.json
+++ b/configs/champion/archetypes_unified/production/archetype_a_spring.json
@@ -1,0 +1,149 @@
+{
+  "version": "archetype_a_production_v1",
+  "profile": "Archetype A - Spring (Production)",
+  "description": "Bull market archetype - Wyckoff Spring detection at accumulation lows",
+  "_comment_overview": "============ ARCHETYPE A - SPRING ============",
+  "_comment_strategy": "Detects Wyckoff Spring events where price breaks below support then rapidly recovers, indicating strong buying pressure",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.40,
+      "liquidity": 0.25,
+      "momentum": 0.20,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": true,
+    "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "spring": {
+        "direction": "long",
+        "archetype_weight": 2.0,
+        "fusion_threshold": 0.35,
+        "min_confidence": 0.4,
+        "spring_depth_min": 0.005,
+        "spring_depth_max": 0.03,
+        "recovery_bars_max": 3,
+        "volume_spike_min": 1.5,
+        "wick_ratio_min": 0.4,
+        "wyckoff_phase_required": ["A", "B"],
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.5,
+        "cooldown_bars": 12
+      }
+    },
+    "exits": {
+      "spring": {
+        "trail_atr": 2.0,
+        "time_limit_hours": 72
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "spring": 0.5 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "spring": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "spring": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "spring": 2.0 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "A",
+    "archetype_name": "Spring",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Low frequency, high quality reversal setups at accumulation zones"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.25,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_b_order_block_retest.json
+++ b/configs/champion/archetypes_unified/production/archetype_b_order_block_retest.json
@@ -1,0 +1,148 @@
+{
+  "version": "archetype_b_production_v1",
+  "profile": "Archetype B - Order Block Retest (Production)",
+  "description": "Bull market archetype - Smart Money Concepts order block retest entries",
+  "_comment_overview": "============ ARCHETYPE B - ORDER BLOCK RETEST ============",
+  "_comment_strategy": "Identifies bullish order blocks and waits for price to retest them before entering long positions",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.20,
+      "liquidity": 0.25,
+      "momentum": 0.20,
+      "smc": 0.35
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 4,
+    "enable_A": false, "enable_B": true, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "order_block_retest": {
+        "direction": "long",
+        "archetype_weight": 1.8,
+        "fusion_threshold": 0.30,
+        "min_confidence": 0.35,
+        "ob_strength_min": 0.5,
+        "retest_proximity_max": 0.015,
+        "volume_confirmation_min": 1.2,
+        "bos_required": true,
+        "imbalance_fill_pct_min": 0.5,
+        "max_bars_since_ob": 50,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.0,
+        "cooldown_bars": 8
+      }
+    },
+    "exits": {
+      "order_block_retest": {
+        "trail_atr": 1.8,
+        "time_limit_hours": 48
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "order_block_retest": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "order_block_retest": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "order_block_retest": 0.7 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "order_block_retest": 0.3 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "B",
+    "archetype_name": "Order Block Retest",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Medium frequency continuation trades in uptrends"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_c_wick_trap.json
+++ b/configs/champion/archetypes_unified/production/archetype_c_wick_trap.json
@@ -1,0 +1,148 @@
+{
+  "version": "archetype_c_production_v1",
+  "profile": "Archetype C - Wick Trap (Production)",
+  "description": "Bull market archetype - Bullish wick rejections at support levels",
+  "_comment_overview": "============ ARCHETYPE C - WICK TRAP ============",
+  "_comment_strategy": "Detects strong wick rejections below support that trap bearish traders",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.25,
+      "liquidity": 0.35,
+      "momentum": 0.25,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 5,
+    "enable_A": false, "enable_B": false, "enable_C": true, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "wick_trap": {
+        "direction": "long",
+        "archetype_weight": 1.5,
+        "fusion_threshold": 0.30,
+        "min_confidence": 0.35,
+        "wick_ratio_min": 0.5,
+        "wick_size_min": 0.01,
+        "body_size_max": 0.005,
+        "volume_spike_min": 1.3,
+        "rapid_recovery": true,
+        "recovery_pct_min": 0.6,
+        "max_risk_pct": 0.015,
+        "atr_stop_mult": 1.8,
+        "cooldown_bars": 6
+      }
+    },
+    "exits": {
+      "wick_trap": {
+        "trail_atr": 1.5,
+        "time_limit_hours": 36
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "wick_trap": 1.2 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "wick_trap": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "wick_trap": 1.3 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "wick_trap": 1.5 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "C",
+    "archetype_name": "Wick Trap",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Higher frequency quick reversal trades at support"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_d_failed_continuation.json
+++ b/configs/champion/archetypes_unified/production/archetype_d_failed_continuation.json
@@ -1,0 +1,147 @@
+{
+  "version": "archetype_d_production_v1",
+  "profile": "Archetype D - Failed Continuation (Production)",
+  "description": "Bull market archetype - Bullish reversals after failed bearish continuations",
+  "_comment_overview": "============ ARCHETYPE D - FAILED CONTINUATION ============",
+  "_comment_strategy": "Identifies failed bearish continuation patterns that reverse into bullish moves",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.30,
+      "liquidity": 0.25,
+      "momentum": 0.30,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": true, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "failed_continuation": {
+        "direction": "long",
+        "archetype_weight": 1.8,
+        "fusion_threshold": 0.35,
+        "min_confidence": 0.4,
+        "pattern_failure_threshold": 0.7,
+        "reversal_strength_min": 1.4,
+        "volume_divergence_min": 0.3,
+        "momentum_shift_required": true,
+        "structure_break_required": true,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.2,
+        "cooldown_bars": 10
+      }
+    },
+    "exits": {
+      "failed_continuation": {
+        "trail_atr": 1.8,
+        "time_limit_hours": 48
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "failed_continuation": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "failed_continuation": 1.2 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "failed_continuation": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "failed_continuation": 1.8 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "D",
+    "archetype_name": "Failed Continuation",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Medium frequency reversal trades at failed pattern points"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_e_volume_exhaustion.json
+++ b/configs/champion/archetypes_unified/production/archetype_e_volume_exhaustion.json
@@ -1,0 +1,147 @@
+{
+  "version": "archetype_e_production_v1",
+  "profile": "Archetype E - Volume Exhaustion (Production)",
+  "description": "Bull market archetype - Bullish reversals at volume exhaustion lows",
+  "_comment_overview": "============ ARCHETYPE E - VOLUME EXHAUSTION ============",
+  "_comment_strategy": "Detects selling exhaustion with volume climax followed by bullish reversal",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.30,
+      "liquidity": 0.20,
+      "momentum": 0.35,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": true,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "volume_exhaustion": {
+        "direction": "long",
+        "archetype_weight": 2.0,
+        "fusion_threshold": 0.35,
+        "min_confidence": 0.4,
+        "volume_climax_z_min": 2.0,
+        "volume_decline_pct_min": 0.5,
+        "price_stabilization_bars": 3,
+        "reversal_confirmation_required": true,
+        "selling_pressure_exhaustion_min": 0.7,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.5,
+        "cooldown_bars": 12
+      }
+    },
+    "exits": {
+      "volume_exhaustion": {
+        "trail_atr": 2.0,
+        "time_limit_hours": 60
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "volume_exhaustion": 0.8 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "volume_exhaustion": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "volume_exhaustion": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "volume_exhaustion": 2.0 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "E",
+    "archetype_name": "Volume Exhaustion",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Low frequency high quality reversal setups at volume climax"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_f_exhaustion_reversal.json
+++ b/configs/champion/archetypes_unified/production/archetype_f_exhaustion_reversal.json
@@ -1,0 +1,147 @@
+{
+  "version": "archetype_f_production_v1",
+  "profile": "Archetype F - Exhaustion Reversal (Production)",
+  "description": "Bull market archetype - Momentum exhaustion reversals to the upside",
+  "_comment_overview": "============ ARCHETYPE F - EXHAUSTION REVERSAL ============",
+  "_comment_strategy": "Identifies bearish momentum exhaustion followed by strong bullish reversal",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.25,
+      "liquidity": 0.25,
+      "momentum": 0.35,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": true, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "exhaustion_reversal": {
+        "direction": "long",
+        "archetype_weight": 1.8,
+        "fusion_threshold": 0.35,
+        "min_confidence": 0.4,
+        "rsi_oversold_max": 30,
+        "momentum_deceleration_min": 0.6,
+        "divergence_required": true,
+        "reversal_candle_strength_min": 1.5,
+        "volume_confirmation_min": 1.3,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.3,
+        "cooldown_bars": 10
+      }
+    },
+    "exits": {
+      "exhaustion_reversal": {
+        "trail_atr": 1.8,
+        "time_limit_hours": 48
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "exhaustion_reversal": 0.7 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "exhaustion_reversal": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "exhaustion_reversal": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "exhaustion_reversal": 2.0 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "F",
+    "archetype_name": "Exhaustion Reversal",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Medium frequency reversal trades at momentum exhaustion"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_g_liquidity_sweep.json
+++ b/configs/champion/archetypes_unified/production/archetype_g_liquidity_sweep.json
@@ -1,0 +1,148 @@
+{
+  "version": "archetype_g_production_v1",
+  "profile": "Archetype G - Liquidity Sweep (Production)",
+  "description": "Bull market archetype - Bullish entries after liquidity sweeps below lows",
+  "_comment_overview": "============ ARCHETYPE G - LIQUIDITY SWEEP ============",
+  "_comment_strategy": "Detects liquidity sweeps below recent lows followed by bullish reclaim",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.25,
+      "liquidity": 0.35,
+      "momentum": 0.20,
+      "smc": 0.20
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 4,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": true, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "liquidity_sweep": {
+        "direction": "long",
+        "archetype_weight": 1.7,
+        "fusion_threshold": 0.30,
+        "min_confidence": 0.35,
+        "sweep_depth_min": 0.003,
+        "sweep_depth_max": 0.015,
+        "reclaim_speed_bars_max": 3,
+        "liquidity_pool_size_min": 0.5,
+        "volume_spike_min": 1.4,
+        "structure_confirmed": true,
+        "max_risk_pct": 0.015,
+        "atr_stop_mult": 2.0,
+        "cooldown_bars": 8
+      }
+    },
+    "exits": {
+      "liquidity_sweep": {
+        "trail_atr": 1.8,
+        "time_limit_hours": 36
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "liquidity_sweep": 1.3 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "liquidity_sweep": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "liquidity_sweep": 0.8 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "liquidity_sweep": 0.5 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "G",
+    "archetype_name": "Liquidity Sweep",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Medium frequency smart money continuation trades"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_h_momentum_continuation.json
+++ b/configs/champion/archetypes_unified/production/archetype_h_momentum_continuation.json
@@ -1,0 +1,148 @@
+{
+  "version": "archetype_h_production_v1",
+  "profile": "Archetype H - Momentum Continuation (Production)",
+  "description": "Bull market archetype - Continuation entries in strong uptrends",
+  "_comment_overview": "============ ARCHETYPE H - MOMENTUM CONTINUATION ============",
+  "_comment_strategy": "Identifies pullbacks in strong uptrends for continuation entries",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.20,
+      "liquidity": 0.20,
+      "momentum": 0.45,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 5,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": true, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "momentum_continuation": {
+        "direction": "long",
+        "archetype_weight": 1.5,
+        "fusion_threshold": 0.28,
+        "min_confidence": 0.32,
+        "trend_strength_min": 0.6,
+        "pullback_depth_min": 0.01,
+        "pullback_depth_max": 0.05,
+        "momentum_sustained": true,
+        "ema_alignment_required": true,
+        "volume_healthy": true,
+        "max_risk_pct": 0.015,
+        "atr_stop_mult": 1.8,
+        "cooldown_bars": 6
+      }
+    },
+    "exits": {
+      "momentum_continuation": {
+        "trail_atr": 1.5,
+        "time_limit_hours": 36
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "momentum_continuation": 2.0 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "momentum_continuation": 1.2 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "momentum_continuation": 0.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "momentum_continuation": 0.2 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "H",
+    "archetype_name": "Momentum Continuation",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Higher frequency trend-following trades in risk-on"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_k_trap_within_trend.json
+++ b/configs/champion/archetypes_unified/production/archetype_k_trap_within_trend.json
@@ -1,0 +1,148 @@
+{
+  "version": "archetype_k_production_v1",
+  "profile": "Archetype K - Trap Within Trend (Production)",
+  "description": "Bull market archetype - Counter-trend traps within established uptrend",
+  "_comment_overview": "============ ARCHETYPE K - TRAP WITHIN TREND ============",
+  "_comment_strategy": "Identifies false breakdowns in uptrends that trap counter-trend traders",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.25,
+      "liquidity": 0.30,
+      "momentum": 0.30,
+      "smc": 0.15
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 4,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": true, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "trap_within_trend": {
+        "direction": "long",
+        "archetype_weight": 1.6,
+        "fusion_threshold": 0.32,
+        "min_confidence": 0.35,
+        "uptrend_strength_min": 0.5,
+        "false_breakdown_depth_min": 0.008,
+        "false_breakdown_depth_max": 0.025,
+        "recovery_speed_bars_max": 4,
+        "liquidity_grab_confirmed": true,
+        "volume_spike_min": 1.3,
+        "max_risk_pct": 0.015,
+        "atr_stop_mult": 2.0,
+        "cooldown_bars": 8
+      }
+    },
+    "exits": {
+      "trap_within_trend": {
+        "trail_atr": 1.8,
+        "time_limit_hours": 48
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "trap_within_trend": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "trap_within_trend": 1.2 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "trap_within_trend": 0.8 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "trap_within_trend": 0.3 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "K",
+    "archetype_name": "Trap Within Trend",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Medium frequency trap reversal trades in uptrends"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_l_retest_cluster.json
+++ b/configs/champion/archetypes_unified/production/archetype_l_retest_cluster.json
@@ -1,0 +1,148 @@
+{
+  "version": "archetype_l_production_v1",
+  "profile": "Archetype L - Retest Cluster (Production)",
+  "description": "Bull market archetype - Multiple timeframe confluence retests",
+  "_comment_overview": "============ ARCHETYPE L - RETEST CLUSTER ============",
+  "_comment_strategy": "Identifies confluence zones where multiple support levels align for high-probability entries",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.25,
+      "liquidity": 0.25,
+      "momentum": 0.25,
+      "smc": 0.25
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": true,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "retest_cluster": {
+        "direction": "long",
+        "archetype_weight": 2.0,
+        "fusion_threshold": 0.38,
+        "min_confidence": 0.42,
+        "min_confluence_factors": 3,
+        "zone_proximity_max": 0.01,
+        "fib_alignment_required": true,
+        "volume_profile_node": true,
+        "order_block_present": true,
+        "temporal_confluence_min": 0.6,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.2,
+        "cooldown_bars": 10
+      }
+    },
+    "exits": {
+      "retest_cluster": {
+        "trail_atr": 2.0,
+        "time_limit_hours": 60
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "retest_cluster": 1.3 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "retest_cluster": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "retest_cluster": 1.2 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "retest_cluster": 0.8 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "L",
+    "archetype_name": "Retest Cluster",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Low-medium frequency high quality confluence setups"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_m_confluence_breakout.json
+++ b/configs/champion/archetypes_unified/production/archetype_m_confluence_breakout.json
@@ -1,0 +1,149 @@
+{
+  "version": "archetype_m_production_v1",
+  "profile": "Archetype M - Confluence Breakout (Production)",
+  "description": "Bull market archetype - High confluence breakout entries",
+  "_comment_overview": "============ ARCHETYPE M - CONFLUENCE BREAKOUT ============",
+  "_comment_strategy": "Identifies strong breakouts with multiple confirming factors across all domains",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.25,
+      "liquidity": 0.25,
+      "momentum": 0.25,
+      "smc": 0.25
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": true, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "confluence_breakout": {
+        "direction": "long",
+        "archetype_weight": 2.2,
+        "fusion_threshold": 0.40,
+        "min_confidence": 0.45,
+        "breakout_strength_min": 0.7,
+        "volume_surge_min": 2.0,
+        "all_domains_aligned": true,
+        "wyckoff_phase_alignment": true,
+        "smc_structure_confirmed": true,
+        "temporal_alignment_min": 0.65,
+        "macro_regime_favorable": true,
+        "max_risk_pct": 0.025,
+        "atr_stop_mult": 2.5,
+        "cooldown_bars": 12
+      }
+    },
+    "exits": {
+      "confluence_breakout": {
+        "trail_atr": 2.2,
+        "time_limit_hours": 72
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "confluence_breakout": 1.8 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "confluence_breakout": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "confluence_breakout": 0.6 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "confluence_breakout": 0.3 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "M",
+    "archetype_name": "Confluence Breakout",
+    "market_regime": "bull",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Low frequency premium quality breakout setups"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_s1_liquidity_vacuum.json
+++ b/configs/champion/archetypes_unified/production/archetype_s1_liquidity_vacuum.json
@@ -1,0 +1,169 @@
+{
+  "version": "archetype_s1_production_v1",
+  "profile": "Archetype S1 - Liquidity Vacuum (Production)",
+  "description": "Bear market archetype - Multi-bar capitulation reversals",
+  "_comment_overview": "============ ARCHETYPE S1 - LIQUIDITY VACUUM ============",
+  "_comment_strategy": "Production config based on s1_full.json - detects severe liquidity drains with capitulation",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for S1"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 1.0,
+    "weights": {
+      "wyckoff": 0.0,
+      "liquidity": 0.0,
+      "momentum": 0.0,
+      "smc": 0.0
+    },
+    "_comment": "Legacy fusion disabled"
+  },
+  "risk": {
+    "base_risk_pct": 0.02,
+    "max_position_size_pct": 0.12,
+    "max_portfolio_risk_pct": 0.1
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 0,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": true, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "liquidity_vacuum": {
+        "direction": "long",
+        "archetype_weight": 2.5,
+        "use_v2_logic": true,
+        "use_confluence": true,
+        "use_regime_filter": true,
+        "capitulation_depth_max": -0.2,
+        "crisis_composite_min": 0.35,
+        "confluence_min_conditions": 3,
+        "confluence_threshold": 0.65,
+        "confluence_weights": {
+          "capitulation_depth_score": 0.2,
+          "crisis_environment": 0.15,
+          "volume_climax_3b": 0.08,
+          "wick_exhaustion_3b": 0.07,
+          "liquidity_drain_severity": 0.1,
+          "liquidity_velocity_score": 0.08,
+          "liquidity_persistence_score": 0.07,
+          "funding_reversal": 0.12,
+          "oversold": 0.08,
+          "volatility_spike": 0.05
+        },
+        "volume_climax_3b_min": 0.5,
+        "wick_exhaustion_3b_min": 0.6,
+        "allowed_regimes": ["risk_off", "crisis"],
+        "drawdown_override_pct": 0.1,
+        "require_regime_or_drawdown": true,
+        "liquidity_max": 0.17240186439426278,
+        "volume_z_min": 1.9672749534023555,
+        "wick_lower_min": 0.33764190571119296,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.756052450054769,
+        "cooldown_bars": 12.0,
+        "fusion_threshold": 0.5442544322373216
+      }
+    },
+    "exits": {
+      "liquidity_vacuum": {
+        "trail_atr": 2.0,
+        "time_limit_hours": 72
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "liquidity_vacuum": 0.5 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "liquidity_vacuum": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "liquidity_vacuum": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "liquidity_vacuum": 2.0 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "S1",
+    "archetype_name": "Liquidity Vacuum",
+    "market_regime": "bear",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "40-60 trades/year, 50-60% win rate, crisis reversal specialist"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_s3_whipsaw.json
+++ b/configs/champion/archetypes_unified/production/archetype_s3_whipsaw.json
@@ -1,0 +1,149 @@
+{
+  "version": "archetype_s3_production_v1",
+  "profile": "Archetype S3 - Whipsaw (Production)",
+  "description": "Neutral archetype - Range-bound mean reversion trades",
+  "_comment_overview": "============ ARCHETYPE S3 - WHIPSAW ============",
+  "_comment_strategy": "Detects tight range conditions with rapid mean reversion opportunities",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.20,
+      "liquidity": 0.30,
+      "momentum": 0.30,
+      "smc": 0.20
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.015,
+    "max_position_size_pct": 0.15,
+    "max_portfolio_risk_pct": 0.08
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 6,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": true, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "whipsaw": {
+        "direction": "neutral",
+        "_note_direction": "S3 can take LONG or SHORT based on range position",
+        "archetype_weight": 1.2,
+        "fusion_threshold": 0.25,
+        "min_confidence": 0.30,
+        "range_tightness_min": 0.6,
+        "atr_compression_min": 0.5,
+        "range_boundary_proximity_max": 0.02,
+        "mean_reversion_speed_min": 0.7,
+        "volume_decline_required": true,
+        "quick_scalp_mode": true,
+        "max_risk_pct": 0.01,
+        "atr_stop_mult": 1.5,
+        "cooldown_bars": 4
+      }
+    },
+    "exits": {
+      "whipsaw": {
+        "trail_atr": 1.2,
+        "time_limit_hours": 12
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "whipsaw": 0.3 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "whipsaw": 2.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "whipsaw": 0.5 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "whipsaw": 0.1 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "S3",
+    "archetype_name": "Whipsaw",
+    "market_regime": "neutral",
+    "direction": "neutral",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "Higher frequency range-bound scalping in neutral regime"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_s4_funding_divergence.json
+++ b/configs/champion/archetypes_unified/production/archetype_s4_funding_divergence.json
@@ -1,0 +1,154 @@
+{
+  "version": "archetype_s4_production_v1",
+  "profile": "Archetype S4 - Funding Divergence (Production)",
+  "description": "Bear market archetype - Negative funding with price resilience",
+  "_comment_overview": "============ ARCHETYPE S4 - FUNDING DIVERGENCE ============",
+  "_comment_strategy": "Production config based on s4_full.json - detects funding rate divergence setups",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment_ml": "ML filter disabled"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.35,
+      "liquidity": 0.30,
+      "momentum": 0.35,
+      "smc": 0.0
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.015,
+    "max_position_size_pct": 0.15,
+    "max_portfolio_risk_pct": 0.08
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 3,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": true,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.10,
+      "funding_divergence": {
+        "direction": "long",
+        "archetype_weight": 2.5,
+        "fusion_threshold": 0.7824,
+        "final_fusion_gate": 0.7824,
+        "funding_z_max": -1.976,
+        "resilience_min": 0.555,
+        "liquidity_max": 0.348,
+        "cooldown_bars": 11,
+        "max_risk_pct": 0.02,
+        "atr_stop_mult": 2.282,
+        "use_runtime_features": true,
+        "funding_lookback": 24,
+        "price_lookback": 12,
+        "weights": {
+          "funding_negative": 0.40,
+          "price_resilience": 0.30,
+          "volume_quiet": 0.15,
+          "liquidity_thin": 0.15
+        }
+      }
+    },
+    "exits": {
+      "funding_divergence": {
+        "trail_atr": 1.5,
+        "time_limit_hours": 48
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "funding_divergence": 0.5 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "funding_divergence": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "funding_divergence": 1.0 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "funding_divergence": 1.5 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "S4",
+    "archetype_name": "Funding Divergence",
+    "market_regime": "bear",
+    "direction": "long",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "12 trades/year, PF 2.22, 55.7% win rate"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_s5_long_squeeze.json
+++ b/configs/champion/archetypes_unified/production/archetype_s5_long_squeeze.json
@@ -1,0 +1,153 @@
+{
+  "version": "archetype_s5_production_v1",
+  "profile": "Archetype S5 - Long Squeeze (Production)",
+  "description": "Bear market archetype - Short entries on long position liquidations",
+  "_comment_overview": "============ ARCHETYPE S5 - LONG SQUEEZE ============",
+  "_comment_strategy": "Production config based on s5_full.json - detects overheated longs with funding extremes",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment_ml": "ML filter disabled"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.35,
+      "liquidity": 0.3,
+      "momentum": 0.35,
+      "smc": 0.0
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.015,
+    "max_position_size_pct": 0.15,
+    "max_portfolio_risk_pct": 0.08
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 2,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": true, "enable_S6": false, "enable_S7": false, "enable_S8": false,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "long_squeeze": {
+        "direction": "short",
+        "_note_direction": "S5 takes SHORT positions",
+        "archetype_weight": 2.5,
+        "fusion_threshold": 0.45,
+        "final_fusion_gate": 0.45,
+        "funding_z_min": 1.5,
+        "rsi_min": 70,
+        "liquidity_max": 0.2,
+        "cooldown_bars": 8,
+        "max_risk_pct": 0.015,
+        "atr_stop_mult": 3.0,
+        "_calibration_metadata": {
+          "applied_date": "2025-12-08",
+          "study_name": "S5_HighConv_v1_Optimization",
+          "best_pf": 1.86,
+          "trades_per_year": 9,
+          "win_rate": 0.556
+        }
+      }
+    },
+    "exits": {
+      "long_squeeze": {
+        "trail_atr": 1.5,
+        "time_limit_hours": 24
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "long_squeeze": 0.0 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "long_squeeze": 0.5 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "long_squeeze": 2.2 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "long_squeeze": 2.5 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "S5",
+    "archetype_name": "Long Squeeze",
+    "market_regime": "bear",
+    "direction": "short",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "9 trades/year, PF 1.86, 55.6% win rate"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/production/archetype_s8_volume_fade_chop.json
+++ b/configs/champion/archetypes_unified/production/archetype_s8_volume_fade_chop.json
@@ -1,0 +1,149 @@
+{
+  "version": "archetype_s8_production_v1",
+  "profile": "Archetype S8 - Volume Fade Chop (Production)",
+  "description": "Neutral archetype - Low volume choppy market fade trades",
+  "_comment_overview": "============ ARCHETYPE S8 - VOLUME FADE CHOP ============",
+  "_comment_strategy": "Fades low-conviction moves in choppy, low volume conditions",
+  "adaptive_fusion": false,
+  "regime_classifier": {
+    "model_path": "models/regime_classifier_gmm.pkl",
+    "feature_order": [
+      "VIX", "DXY", "MOVE", "YIELD_2Y", "YIELD_10Y",
+      "USDT.D", "BTC.D", "TOTAL", "TOTAL2",
+      "funding", "oi", "rv_20d", "rv_60d"
+    ],
+    "zero_fill_missing": false,
+    "regime_override": {}
+  },
+  "ml_filter": {
+    "enabled": false,
+    "_comment": "ML filter disabled for initial production"
+  },
+  "fusion": {
+    "entry_threshold_confidence": 0.99,
+    "weights": {
+      "wyckoff": 0.15,
+      "liquidity": 0.25,
+      "momentum": 0.40,
+      "smc": 0.20
+    }
+  },
+  "risk": {
+    "base_risk_pct": 0.01,
+    "max_position_size_pct": 0.10,
+    "max_portfolio_risk_pct": 0.05
+  },
+  "archetypes": {
+    "use_archetypes": true,
+    "max_trades_per_day": 8,
+    "enable_A": false, "enable_B": false, "enable_C": false, "enable_D": false, "enable_E": false,
+    "enable_F": false, "enable_G": false, "enable_H": false, "enable_K": false, "enable_L": false,
+    "enable_M": false, "enable_S1": false, "enable_S2": false, "enable_S3": false, "enable_S4": false,
+    "enable_S5": false, "enable_S6": false, "enable_S7": false, "enable_S8": true,
+    "thresholds": {
+      "min_liquidity": 0.1,
+      "volume_fade_chop": {
+        "direction": "neutral",
+        "_note_direction": "S8 fades moves in either direction",
+        "archetype_weight": 1.0,
+        "fusion_threshold": 0.22,
+        "min_confidence": 0.28,
+        "volume_z_max": -0.5,
+        "chop_index_min": 0.6,
+        "move_without_conviction": true,
+        "fade_breakout_failures": true,
+        "atr_declining": true,
+        "quick_exit_mode": true,
+        "max_risk_pct": 0.008,
+        "atr_stop_mult": 1.3,
+        "cooldown_bars": 3
+      }
+    },
+    "exits": {
+      "volume_fade_chop": {
+        "trail_atr": 1.0,
+        "time_limit_hours": 8
+      }
+    },
+    "routing": {
+      "risk_on": {
+        "weights": { "volume_fade_chop": 0.2 },
+        "final_gate_delta": 0.0
+      },
+      "neutral": {
+        "weights": { "volume_fade_chop": 1.5 },
+        "final_gate_delta": 0.0
+      },
+      "risk_off": {
+        "weights": { "volume_fade_chop": 0.8 },
+        "final_gate_delta": 0.0
+      },
+      "crisis": {
+        "weights": { "volume_fade_chop": 0.1 },
+        "final_gate_delta": 0.0
+      }
+    }
+  },
+  "_production_metadata": {
+    "created": "2025-12-15",
+    "archetype_code": "S8",
+    "archetype_name": "Volume Fade Chop",
+    "market_regime": "neutral",
+    "direction": "neutral",
+    "enabled_domain_engines": ["wyckoff", "smc", "temporal", "hob", "fusion", "macro"],
+    "expected_behavior": "High frequency low-risk fade trades in choppy conditions"
+  },
+  "feature_flags": {
+    "enable_wyckoff": true,
+    "enable_smc": true,
+    "enable_temporal": true,
+    "enable_hob": true,
+    "enable_fusion": true,
+    "enable_macro": true,
+    "use_temporal_confluence": true,
+    "use_fusion_layer": true,
+    "use_macro_regime": true,
+    "_comment": "All 6 engines enabled - production setup"
+  },
+  "temporal_fusion": {
+    "enabled": true,
+    "use_confluence": true,
+    "min_confluence_score": 0.5,
+    "time_window_hours": 24,
+    "weights": {
+      "fib_time_cluster": 0.30,
+      "volume_time_confluence": 0.25,
+      "regime_time_alignment": 0.25,
+      "wyckoff_pti_confluence": 0.20
+    },
+    "min_multiplier": 0.85,
+    "max_multiplier": 1.25
+  },
+  "wyckoff_events": {
+    "enabled": true,
+    "min_confidence": 0.65,
+    "log_events": true,
+    "avoid_longs_if": ["BC", "UTAD"],
+    "boost_longs_if": {
+      "LPS": 1.15,
+      "Spring-A": 1.20,
+      "SOS": 1.15,
+      "PTI_confluence": 1.25
+    },
+    "reduce_position_size_if": ["LPSY", "UT"]
+  },
+  "smc_engine": {
+    "enabled": true,
+    "min_score": 0.5,
+    "detect_bos": true,
+    "detect_choch": true,
+    "detect_liquidity_sweeps": true,
+    "boost_threshold": 0.6
+  },
+  "hob_engine": {
+    "enabled": true,
+    "use_demand_zones": true,
+    "use_supply_zones": true,
+    "min_zone_strength": 0.5
+  }
+}

--- a/configs/champion/archetypes_unified/retest_cluster.yaml
+++ b/configs/champion/archetypes_unified/retest_cluster.yaml
@@ -1,0 +1,65 @@
+name: retest_cluster
+display_name: Retest Cluster / Fakeout Real Move
+aliases:
+- L
+- frm
+- false_break
+- volume_exhaustion
+- fakeout_real_move
+direction: long
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.3
+  momentum: 0.2
+  smc: 0.25
+thresholds:
+  fusion_threshold: 0.18
+  order_block_distance_max: 600.0
+  rsi_min: 35.0
+  vol_z: 0.5
+  rsi_edge: 65.0
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: volume_zscore
+  op: min
+  value: 0.5
+  description: Volume spike for real move
+- feature: derived:rsi_extreme_65
+  op: bool_true
+  description: RSI at extreme
+- feature: temporal_confluence_score
+  op: min
+  value: 0.45
+  nan_policy: skip
+  description: Temporal confluence validates cluster quality
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.15
+  runner_trailing_atr: 2.5
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 3.0
+  atr_tp_mult: 2.2
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.8
+  crisis: 0.7
+allowed_regimes: []
+description: Fakeout followed by genuine structural move. Multi-level confluence pattern.
+priority: 6
+enabled: true

--- a/configs/champion/archetypes_unified/spring.yaml
+++ b/configs/champion/archetypes_unified/spring.yaml
@@ -1,0 +1,58 @@
+name: spring
+display_name: Spring / UTAD
+aliases:
+- A
+- trap_reversal
+- wyckoff_spring_utad
+direction: long
+fusion_weights:
+  wyckoff: 0.6
+  liquidity: 0.2
+  momentum: 0.1
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.18
+  pti_score_threshold: 0.05
+  disp_atr_multiplier: 0.0
+  pti: 0.05
+  disp_atr: 0.0
+  fusion: 0.18
+  wick_lower_threshold: 0.2
+  cooling_period_bars: 36
+hard_gates:
+- feature: tf1h_pti_score
+  op: min
+  value: 0.1
+  nan_policy: skip
+  description: Minimum PTI score (tightened from 0.05)
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels:
+  - 1.0
+  - 2.0
+  - 3.0
+  scale_out_pcts:
+  - 0.3
+  - 0.3
+  - 0.3
+  runner_pct: 0.1
+  runner_trailing_atr: 3.0
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 1.9
+  atr_tp_mult: 4.5
+regime_preferences:
+  risk_on: 0.5
+  neutral: 1.0
+  risk_off: 1.5
+  crisis: 2.0
+allowed_regimes: []
+description: PTI-based spring/UTAD detection with displacement confirmation. Counter-trend
+  reversal at accumulation lows.
+priority: 1
+enabled: true

--- a/configs/champion/archetypes_unified/spring_example.yaml
+++ b/configs/champion/archetypes_unified/spring_example.yaml
@@ -1,0 +1,45 @@
+# Spring Archetype Configuration
+# Wyckoff Spring pattern - capitulation reversal
+
+archetype:
+  name: spring
+  direction: long
+  description: Wyckoff Spring pattern - capitulation reversal
+
+  # ARCHETYPE-SPECIFIC fusion calculation
+  # Spring emphasizes Wyckoff (counter-trend) + liquidity vacuum
+  fusion_weights:
+    wyckoff: 0.70    # High weight on Wyckoff phases
+    liquidity: 0.15  # Need liquidity vacuum
+    momentum: 0.10   # Low momentum (reversal setup)
+    smc: 0.05        # Minimal SMC emphasis
+
+  # ARCHETYPE-SPECIFIC thresholds
+  thresholds:
+    entry: 0.35          # Fusion score threshold
+    min_liquidity: 0.12  # Minimum liquidity required
+
+  # ARCHETYPE-SPECIFIC exit logic
+  exits:
+    atr_stop_mult: 2.5    # Stop loss = entry - 2.5×ATR
+    atr_tp_mult: 2.5      # Take profit = entry + 2.5×ATR
+    max_hold_hours: 72    # Max 3 days
+    trailing_stop: true   # Use trailing stop
+
+  # ARCHETYPE-SPECIFIC position sizing
+  position_sizing:
+    max_risk_pct: 0.02  # 2% risk per trade
+
+  # Regime sensitivity (for portfolio allocator)
+  # Spring works in all regimes but strongest in crisis
+  regime_weights:
+    crisis: 0.10    # Minimal weight in crisis (false springs)
+    risk_off: 0.30  # Low weight in risk-off
+    neutral: 0.80   # Good weight in neutral
+    risk_on: 1.00   # Full weight in risk-on
+
+  # Pattern-specific detection parameters
+  pattern_params:
+    min_wyckoff_confidence: 0.65
+    require_spring_event: true
+    allow_lpsy: false

--- a/configs/champion/archetypes_unified/spring_utad_baseline.json
+++ b/configs/champion/archetypes_unified/spring_utad_baseline.json
@@ -1,0 +1,31 @@
+{
+  "archetype": "spring_utad",
+  "description": "Spring/UTAD (A) - Wyckoff spring accumulation reversals",
+  "direction": "long",
+  "enabled": true,
+  "thresholds": {
+    "min_wyckoff_confidence": 0.50,
+    "min_wick_lower_ratio": 0.25,
+    "min_volume_zscore": 1.0,
+    "min_fusion_score": 0.35,
+    "max_rsi_entry": 70,
+    "max_adx_downtrend": 25,
+    "wyckoff_weight": 0.30,
+    "smc_weight": 0.25,
+    "price_action_weight": 0.25,
+    "momentum_weight": 0.15,
+    "regime_weight": 0.05
+  },
+  "allowed_regimes": ["risk_on", "neutral"],
+  "risk_management": {
+    "atr_stop_mult": 2.5,
+    "max_risk_pct": 0.02,
+    "take_profit_r": 3.0
+  },
+  "notes": [
+    "Baseline config with permissive thresholds for discovery",
+    "Optimized for detecting Wyckoff spring reversals",
+    "Primary signal: wyckoff_spring_a or wyckoff_spring_b events",
+    "Domain engines: Wyckoff (30%), SMC (25%), Price Action (25%)"
+  ]
+}

--- a/configs/champion/archetypes_unified/trap_within_trend.yaml
+++ b/configs/champion/archetypes_unified/trap_within_trend.yaml
@@ -1,0 +1,70 @@
+name: trap_within_trend
+display_name: Trap Within Trend
+aliases:
+- H
+- trap
+- trap_legacy
+- htf_trap
+direction: long
+fusion_weights:
+  wyckoff: 0.35
+  liquidity: 0.35
+  momentum: 0.15
+  smc: 0.15
+thresholds:
+  fusion_threshold: 0.18
+  adx_threshold: 14.0
+  liquidity_threshold: 0.43
+  quality_threshold: 0.4
+  wick_multiplier: 1.5
+  cooling_period_bars: 24
+hard_gates:
+- feature: derived:wick_anomaly
+  op: bool_true
+  description: Wick against trend (>35% of candle range)
+- feature: volume_zscore
+  op: min
+  value: 0.0
+  description: At least median volume (real traps have volume)
+- feature: wick_lower_ratio
+  op: min
+  value: 0.25
+  nan_policy: fail
+  description: Wick direction against trend (lower wick dominant for long trap)
+- feature: bars_since_pivot
+  op: max
+  value: 110
+  nan_policy: skip
+  description: Setup recency - stale pivots lose edge
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.15
+  runner_trailing_atr: 2.5
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 4.6
+  atr_tp_mult: 5.1
+regime_preferences:
+  risk_on: 1.3
+  neutral: 1.0
+  risk_off: 0.7
+  crisis: 0.5
+allowed_regimes: []
+description: 'HTF trend + liquidity drop + wick against trend. False breakdown in
+  uptrend. [V14-REQUANTILED 2026-06-11: liquidity_threshold 0.72->0.43 = identical
+  percentile (q90.3) on live-path distribution]'
+priority: 5
+enabled: true

--- a/configs/champion/archetypes_unified/trap_within_trend_baseline.json
+++ b/configs/champion/archetypes_unified/trap_within_trend_baseline.json
@@ -1,0 +1,31 @@
+{
+  "archetype": "trap_within_trend",
+  "description": "Trap Within Trend (H) - False breakdown continuations in uptrends",
+  "direction": "long",
+  "enabled": true,
+  "thresholds": {
+    "min_htf_trend": 0,
+    "min_wick_lower_ratio": 0.25,
+    "min_adx": 15,
+    "min_rsi": 40,
+    "min_fusion_score": 0.35,
+    "momentum_weight": 0.35,
+    "price_action_weight": 0.30,
+    "wyckoff_weight": 0.20,
+    "volume_weight": 0.10,
+    "regime_weight": 0.05
+  },
+  "allowed_regimes": ["risk_on", "neutral"],
+  "risk_management": {
+    "atr_stop_mult": 2.0,
+    "max_risk_pct": 0.02,
+    "take_profit_r": 3.0
+  },
+  "notes": [
+    "Baseline config with permissive thresholds for discovery",
+    "Optimized for trend continuation after false breakdown",
+    "Primary signal: 4H uptrend + lower wick trap + recovery",
+    "Domain engines: Momentum (35%), Price Action (30%), Wyckoff (20%)",
+    "REQUIRES higher timeframe uptrend (tf4h_trend_direction > 0)"
+  ]
+}

--- a/configs/champion/archetypes_unified/volume_fade_chop.yaml
+++ b/configs/champion/archetypes_unified/volume_fade_chop.yaml
@@ -1,0 +1,68 @@
+name: volume_fade_chop
+display_name: Volume Fade Chop
+aliases:
+- S8
+direction: neutral
+fusion_weights:
+  wyckoff: 0.15
+  liquidity: 0.35
+  momentum: 0.4
+  smc: 0.1
+thresholds:
+  fusion_threshold: 0.18
+  volume_z_max: -0.6
+  adx_max: 25.0
+  chop_score_min: 0.4
+  vol_max: 0.8
+  rsi_extreme: 65.0
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: volume_zscore
+  op: max
+  value: 0.5
+  description: Low volume
+- feature: adx_14
+  op: max
+  value: 25.0
+  description: No strong trend
+  nan_policy: skip
+- feature: derived:rsi_extreme_65
+  op: bool_true
+  description: RSI at extreme
+- feature: effort_result_ratio
+  op: max
+  value: 1.5
+  nan_policy: skip
+  description: Low effort validates chop (fading conviction)
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 48
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 1.5
+  scale_out_pcts:
+  - 0.3
+  - 0.4
+  - 0.3
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.7
+  atr_tp_mult: 3.8
+regime_preferences:
+  risk_on: 0.7
+  neutral: 1.5
+  risk_off: 0.8
+  crisis: 0.6
+allowed_regimes: []
+description: Low-volume fade in choppy conditions. Scalping specialist for neutral
+  regimes.
+priority: 16
+enabled: true

--- a/configs/champion/archetypes_unified/whipsaw.yaml
+++ b/configs/champion/archetypes_unified/whipsaw.yaml
@@ -1,0 +1,62 @@
+name: whipsaw
+display_name: Whipsaw
+aliases:
+- S3
+direction: neutral
+fusion_weights:
+  wyckoff: 0.25
+  liquidity: 0.3
+  momentum: 0.3
+  smc: 0.15
+thresholds:
+  fusion_threshold: 0.18
+  atr_min: 400.0
+  adx_max: 20.0
+  range_compression: 0.5
+  wick_ratio: 1.5
+  vol_max: 0.8
+  fusion: 0.18
+  cooling_period_bars: 24
+hard_gates:
+- feature: derived:upper_wick_body_ratio
+  op: min
+  value: 1.5
+  description: Upper wick rejection > 1.5x body
+- feature: volume_zscore
+  op: max
+  value: 0.5
+  description: Low volume (no conviction)
+- feature: wyckoff_sow
+  op: bool_true
+  nan_policy: skip
+  description: Sign of Weakness confirms distribution context
+gate_mode: soft
+exit_logic:
+  max_hold_hours: 48
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 1.5
+  scale_out_pcts:
+  - 0.3
+  - 0.3
+  - 0.3
+  runner_pct: 0.0
+  runner_trailing_atr: 2.0
+  trailing_start_r: 0.5
+  trailing_atr_mult: 1.5
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 2.9
+  atr_tp_mult: 5.5
+regime_preferences:
+  risk_on: 0.7
+  neutral: 1.5
+  risk_off: 0.8
+  crisis: 0.6
+allowed_regimes: []
+description: Range-bound mean reversion. Specialist for choppy, directionless markets.
+priority: 13
+enabled: true

--- a/configs/champion/archetypes_unified/whipsaw_example.yaml
+++ b/configs/champion/archetypes_unified/whipsaw_example.yaml
@@ -1,0 +1,38 @@
+# Whipsaw Archetype Configuration
+# Whipsaw pattern - failed breakout with rapid reversal
+
+archetype:
+  name: whipsaw
+  direction: short
+  description: Whipsaw pattern - failed breakout with rapid reversal
+
+  # DIFFERENT fusion weights (emphasize momentum reversal)
+  fusion_weights:
+    wyckoff: 0.10    # Minimal Wyckoff
+    liquidity: 0.30  # Moderate liquidity
+    momentum: 0.50   # High momentum (rapid reversal)
+    smc: 0.10        # Higher SMC emphasis for structure breaks
+
+  thresholds:
+    entry: 0.42          # Higher threshold (selective)
+    min_liquidity: 0.10  # Lower liquidity requirement
+
+  exits:
+    atr_stop_mult: 2.0    # Tight stops (short bias)
+    atr_tp_mult: 3.0      # Wider targets (capitalize on panic)
+    max_hold_hours: 24    # Very short hold (1 day max)
+    trailing_stop: true
+
+  position_sizing:
+    max_risk_pct: 0.015  # 1.5% risk (conservative for shorts)
+
+  regime_weights:
+    crisis: 0.80    # Strong in crisis (whipsaws common)
+    risk_off: 1.00  # Strongest in risk-off
+    neutral: 0.60
+    risk_on: 0.40   # Weaker in risk-on
+
+  pattern_params:
+    min_momentum_reversal: 0.60
+    require_failed_breakout: true
+    max_bars_since_breakout: 2

--- a/configs/champion/archetypes_unified/wick_trap.yaml
+++ b/configs/champion/archetypes_unified/wick_trap.yaml
@@ -1,0 +1,66 @@
+name: wick_trap
+display_name: Wick Trap (Moneytaur)
+aliases:
+- K
+- wick_trap_moneytaur
+- moneytaur
+direction: long
+fusion_weights:
+  wyckoff: 0.2
+  liquidity: 0.4
+  momentum: 0.15
+  smc: 0.25
+thresholds:
+  fusion_threshold: 0.18
+  wick_lower_threshold: 0.3
+  rsi_threshold: 41.0
+  adx_threshold: 14.0
+  liquidity_threshold: 0.43
+  cooling_period_bars: 18
+hard_gates:
+- feature: derived:wick_anomaly
+  op: bool_true
+  description: Lower or upper wick > 35% of candle range
+- feature: volume_zscore
+  op: min
+  value: 0.0
+  description: At least median volume (real wicks have volume behind them)
+- feature: instability_score
+  op: max
+  value: 0.45
+  nan_policy: skip
+  description: 'Low market instability - above 0.45 wicks are noise not reversal (backtest
+    WR 67% vs 49%, p=0.018) [FIXED 2026-07-13: engine emits instability_score; was
+    inert via nan_policy skip]'
+gate_mode: hard
+exit_logic:
+  max_hold_hours: 168
+  scale_out_enabled: true
+  scale_out_levels:
+  - 0.5
+  - 1.0
+  - 2.0
+  scale_out_pcts:
+  - 0.2
+  - 0.2
+  - 0.3
+  runner_pct: 0.15
+  runner_trailing_atr: 2.5
+  trailing_start_r: 1.0
+  trailing_atr_mult: 2.0
+position_sizing:
+  risk_per_trade_pct: 0.02
+  max_position_size_pct: 0.1
+  atr_stop_mult: 4.9
+  atr_tp_mult: 5.3
+regime_preferences:
+  risk_on: 1.2
+  neutral: 1.0
+  risk_off: 0.8
+  crisis: 0.6
+allowed_regimes: []
+description: 'Wick anomaly + ADX > 25 + BOS context. Moneytaur wick rejection pattern.
+  [V14-REQUANTILED 2026-06-11: liquidity_threshold 0.72->0.43 = identical percentile
+  (q90.3) on live-path distribution]'
+priority: 4
+enabled: true

--- a/configs/champion/archetypes_unified/wick_trap_example.yaml
+++ b/configs/champion/archetypes_unified/wick_trap_example.yaml
@@ -1,0 +1,38 @@
+# Wick Trap Archetype Configuration
+# Wick trap reversal - stop hunt with liquidity spike
+
+archetype:
+  name: wick_trap
+  direction: long
+  description: Wick trap reversal - stop hunt with liquidity spike
+
+  # DIFFERENT fusion weights (emphasize liquidity)
+  fusion_weights:
+    wyckoff: 0.20    # Lower Wyckoff emphasis
+    liquidity: 0.60  # Strong liquidity signal required
+    momentum: 0.15   # Moderate momentum
+    smc: 0.05        # Minimal SMC emphasis
+
+  thresholds:
+    entry: 0.28          # Lower threshold (more aggressive)
+    min_liquidity: 0.15  # Higher liquidity requirement
+
+  exits:
+    atr_stop_mult: 3.0    # Wider stops (wick traps need room)
+    atr_tp_mult: 2.5
+    max_hold_hours: 48    # Shorter hold (momentum play)
+    trailing_stop: false  # No trailing (quick in/out)
+
+  position_sizing:
+    max_risk_pct: 0.02
+
+  regime_weights:
+    crisis: 0.05    # Very low in crisis (fake wicks)
+    risk_off: 0.20
+    neutral: 0.70
+    risk_on: 1.00
+
+  pattern_params:
+    min_wick_ratio: 2.0        # Wick must be 2× body
+    require_volume_spike: true
+    max_bars_since_wick: 3

--- a/docs/knowledge/MEMORY.md
+++ b/docs/knowledge/MEMORY.md
@@ -267,6 +267,9 @@ Live code had stale hardcoded CMI weights. Backtester reads from config (correct
 ## Live Deployment
 - **2026-06-30 LIVE PAPER CONFIG** (`configs/champion_paper.json`, service `--config`): FULL BOOK — all 16 archetypes enabled, bypass_threshold=True (data collection), archetype_config_dir=archetypes_v14rq so wick_trap + trap_within_trend now FIRE at re-quantiled 0.43 (were locked out at 0.72). [History: briefly deployed lean core2-only, then user reverted to full-book-plus-unlocked.] deploy.sh excludes deploy/ so the service file installs MANUALLY (scp+systemctl). Breakeven-1R exit = phase 2 (not deployed).
 
+## Unified Strategy 2026-07-13
+- [Unified strategy verdict](unified_strategy_verdict_2026_07_13.md) — level anchoring FAILS the pre-registered bar (U1 sweep starves to n=3; U2 quality violates co-move; U3 near-support intriguing but n=23). THE UNIFIED STRATEGY IS WICK_TRAP, by proof: all knowledge already converged into it. V14L store + live level features = permanent infra; U3 = watch item at n>=30
+
 ## Audit-1 Repairs 2026-07-13
 - [Repair batch + re-baseline](audit1_repair_batch_2026_07_13.md) — BOS emitters FIXED (attr mismatch, 0%->4% fire rate; V14 stored columns still 0 until rebuild); impossible thresholds rescaled; never-validated live-only gates removed; instability gate activated; ls_ratio true z-score. RE-BASELINE: wick_trap validation HOLDS IDENTICALLY (holdout PF 1.43); liquidity_sweep DOWNGRADED (broken-gate penalty was accidentally protective — repaired holdout PF 0.61, edge was artifact). wick_trap = the book's ONLY validated edge
 

--- a/docs/knowledge/unified_strategy_verdict_2026_07_13.md
+++ b/docs/knowledge/unified_strategy_verdict_2026_07_13.md
@@ -1,0 +1,38 @@
+# Unified Strategy Verdict — Level Anchoring Fails the Bar; the Unified Strategy IS wick_trap
+
+**Date**: 2026-07-13. **Build**: V14L store (V14 + 17 level features, no-lookahead), live parity by
+construction (shared module now emits level features hourly). **Grid**: pre-registered, 3 level-gate
+variants on repaired wick_trap vs baseline. **Artifacts**: `results/champion_unified/`, `scripts/champion/unified_grid.py`
+
+## Results (V14L, thresholds enforced)
+| variant | train PF | holdout PF | hold PnL | hold n | full PF | full PnL | 2022 |
+|---|---|---|---|---|---|---|---|
+| baseline (repaired wick_trap) | 1.37 | 1.43 | +$6,764 | 70 | 1.50 | $51,148 | −$8,667 |
+| U1 sweep-required | 2.08 | 0.58 | −$214 | **3** | 1.85 | $7,651 | −$431 |
+| U2 level-quality ≥0.5 | **1.26** | 1.53 | +$7,754 | 67 | 1.44 | $44,169 | −$7,704 |
+| U3 near-support ≤2 ATR | 1.96 | 1.39 | +$1,833 | **23** | 1.71 | $23,195 | **+$244** |
+
+**All three FAIL the pre-registered bar** (train AND holdout PF ≥ baseline, holdout n ≥ 30):
+- U1: starves the strategy (3 holdout trades) — requiring a literal level sweep removes ~90% of
+  wick_trap's trades; the shiny train PF is small-n mirage. The full ES recipe again fails at 1H.
+- U2: holdout up (1.53) but TRAIN DOWN (1.26 < 1.37) — Rule 9 co-move violation; the holdout gain
+  is not trustworthy (single regime window).
+- U3: strong shape (train 1.96, 2022 flips positive) but n=23 < 30 — under-sampled. **Watch item**:
+  re-test when live level-feature data accumulates; NOT deployable.
+
+## The verdict
+**Level anchoring does not robustly improve wick_trap at 1H granularity. The unified strategy is
+wick_trap itself — by proof, not default.** Four months of knowledge (trigger design, exit ladder,
+threshold re-quantiling, repair batch) already converged into the one validated instrument:
+repaired wick_trap — battery ✓, pristine holdout PF 1.43 ✓, CPCV 15/15 ✓, repair re-baseline ✓,
+live and trading. The 16 other archetypes remain research scaffolding / data collection.
+
+## What survives for the future
+- V14L + live level features: permanent infrastructure (any future level hypothesis is now a
+  config test, not a build).
+- U3 near-support: the one intriguing near-miss (2022 positive!) — pre-registered watch item,
+  revisit at n≥30 holdout equivalent.
+- Confirmed again: adding conditions to a validated edge usually subtracts (stack verdict, now this).
+
+## Cross-references
+[[audit1_repair_batch_2026_07_13]] · [[wick_trap_cpcv_2026_07_09]] · [[strategy_book_review_2026_07_10]] (H1 resolved: tested, failed) · [[trader_knowledge_failed_breakdown_es_transfer_2026_06_11]]

--- a/scripts/champion/unified_grid.py
+++ b/scripts/champion/unified_grid.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Unified-strategy grid: does LEVEL ANCHORING improve the validated wick_trap?
+
+Pre-registered variants (gates ADDED to repaired wick_trap; nothing else changes):
+  baseline  repaired wick_trap as-is (holdout PF 1.43)
+  U1_sweep  + sweep_low_event bool_true      (flush must sweep prior-day/swing low)
+  U2_qual   + level_quality_low min 0.5      (flush at an earned level; nan skip)
+  U3_near   + dist_to_support_atr max 2.0    (flush NEAR support, no-chase; nan skip)
+Store: V14L (V14 + level features). Windows: per-year + train + holdout + full.
+Win condition: train AND holdout PF >= baseline, holdout n >= 30 (Rule 9 co-move).
+Honest outcome "levels add nothing" is expected-possible (prior evidence mixed).
+"""
+import json, math, shutil, sys
+from pathlib import Path
+import yaml
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO)); sys.path.insert(0, str(REPO/"scripts/champion"))
+from run_battery import ALL_ARCHETYPES, BASE_CONFIG, CONFIG_DIR
+from bin.backtest_v11_standalone import StandaloneBacktestEngine
+
+STORE = REPO/"data/features_mtf/BTC_1H_FEATURES_V14L_LEVELS.parquet"
+UDIR = REPO/"configs/champion/archetypes_unified"
+OUT = REPO/"results/champion_unified"
+WINDOWS = {**{f"y{y}": (f"{y}-01-01", f"{y}-12-31") for y in range(2018, 2025)},
+           "wfo_train": ("2018-01-01","2022-12-31"),
+           "holdout_2025_26": ("2025-01-01","2026-06-10"),
+           "full": ("2018-01-01","2024-12-31")}
+VARIANTS = {
+    "baseline": None,
+    "U1_sweep": {"feature":"sweep_low_event","op":"bool_true","description":"UNIFIED: flush must sweep a tracked level (prior-day/swing low) [pre-registered 2026-07-13]"},
+    "U2_qual":  {"feature":"level_quality_low","op":"min","value":0.5,"nan_policy":"skip","description":"UNIFIED: flush at an earned level (quality>=0.5) [pre-registered 2026-07-13]"},
+    "U3_near":  {"feature":"dist_to_support_atr","op":"max","value":2.0,"nan_policy":"skip","description":"UNIFIED: entry within 2 ATR of support (no-chase) [pre-registered 2026-07-13]"},
+}
+def set_variant(extra_gate):
+    src = REPO/"configs/champion/archetypes_v14rq/wick_trap.yaml"
+    c = yaml.safe_load(open(src))
+    if extra_gate: c["hard_gates"] = list(c["hard_gates"]) + [extra_gate]
+    yaml.safe_dump(c, open(UDIR/"wick_trap.yaml","w"), sort_keys=False)
+def cfg():
+    c = json.loads(Path(BASE_CONFIG).read_text())
+    c["disabled_archetypes"] = [a for a in ALL_ARCHETYPES if a != "wick_trap"]
+    c.setdefault("adaptive_fusion",{})["bypass_threshold"] = False
+    c["archetype_config_dir"] = "configs/champion/archetypes_unified/"
+    p = CONFIG_DIR/"unified_wt.json"; p.write_text(json.dumps(c, indent=2)); return p
+def run(cp, s, e, od):
+    od.mkdir(parents=True, exist_ok=True); sf = od/"performance_stats.json"
+    if sf.exists(): return json.loads(sf.read_text())
+    eng = StandaloneBacktestEngine(config=json.loads(cp.read_text()), initial_cash=100000.0,
+        commission_rate=0.0002, slippage_bps=3.0, feature_store_path=str(STORE))
+    eng.run(start_date=s, end_date=e)
+    st = eng.get_performance_stats()
+    clean = {k:(str(v) if isinstance(v,float) and (math.isnan(v) or math.isinf(v)) else v) for k,v in st.items()}
+    sf.write_text(json.dumps(clean, indent=2, default=str)); return clean
+def num(v):
+    try: f=float(v); return 0.0 if f!=f else f
+    except (TypeError,ValueError): return 0.0
+def main():
+    OUT.mkdir(parents=True, exist_ok=True); table = {}
+    for vn, gate in VARIANTS.items():
+        set_variant(gate); cp = cfg()
+        print(f"=== {vn} ===", flush=True)
+        res = {w: run(cp, s, e, OUT/vn/w) for w,(s,e) in WINDOWS.items()}
+        table[vn] = {w: {"pf": round(num(r.get("profit_factor")),2),
+                         "pnl": round(num(r.get("total_pnl"))),
+                         "n": int(num(r.get("total_trades")))} for w,r in res.items()}
+    print(f"\n{'variant':<10}{'trainPF':>8}{'holdPF':>7}{'holdPnL':>8}{'holdN':>6}{'fullPF':>7}{'fullPnL':>8}{'2022':>7}")
+    b = table["baseline"]
+    for vn,d in table.items():
+        print(f"{vn:<10}{d['wfo_train']['pf']:>8}{d['holdout_2025_26']['pf']:>7}"
+              f"{d['holdout_2025_26']['pnl']:>8}{d['holdout_2025_26']['n']:>6}"
+              f"{d['full']['pf']:>7}{d['full']['pnl']:>8}{d['y2022']['pnl']:>7}")
+    print("\n=== verdict (train AND holdout PF >= baseline, holdN >= 30) ===")
+    for vn,d in table.items():
+        if vn == "baseline": continue
+        ok = (d['wfo_train']['pf'] >= b['wfo_train']['pf'] and
+              d['holdout_2025_26']['pf'] >= b['holdout_2025_26']['pf'] and
+              d['holdout_2025_26']['n'] >= 30)
+        print(f"  {vn}: {'PASS' if ok else 'fail'}")
+    (OUT/"grid.json").write_text(json.dumps(table, indent=2))
+    set_variant(None)  # restore dir to baseline copy
+    print("GRID DONE")
+if __name__ == "__main__": main()


### PR DESCRIPTION
Built the level-anchoring foundations (V14L enriched store + live level-feature emission via the shared module — parity by construction), then ran the pre-registered grid: does level anchoring improve the validated wick_trap?

**All 3 variants fail the bar**: sweep-required starves it (3 holdout trades); level-quality improves holdout but degrades train (co-move violation); near-support looks strong (train 1.96, 2022 flips positive) but n=23. **Verdict: the unified strategy IS wick_trap — by proof, not default.** Level infra is permanent; U3 is a pre-registered watch item at n≥30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)