### PR TITLE
fix: wyckoff spring_b look-ahead + spring/UT no-context fallback + directional phase

### DIFF
--- a/bin/backtest_v11_standalone.py
+++ b/bin/backtest_v11_standalone.py
@@ -1155,6 +1155,24 @@ class StandaloneBacktestEngine:
                             sig_meta['sizing_boosts']['reasons'].append(
                                 f'local_flush_breadth alt4h={float(abr):+.3f} (1.25x capex)')
 
+                    # Boost 6 (pre-registered study 2026-08-04, config-gated OFF):
+                    # Wyckoff phase-C accumulation context (M2 shadow phase,
+                    # sm_m2_context_only — zero fusion leakage by construction).
+                    # LONG entries taken inside a confirmed accumulation phase C
+                    # ran PF 2.07/1.50 train/holdout vs 1.16/1.09 outside
+                    # (V20 champion trades conditioned on the V21 phase state).
+                    # ALL long archetypes (context qualifier, not archetype-specific).
+                    if (self.config.get('wyckoff_phase_boost') or {}).get('enabled') \
+                       and intent.signal.direction == 'long':
+                        pdir = row.get('wyckoff_phase_dir', None)
+                        if isinstance(pdir, str) and pdir == 'C_accum':
+                            intent.allocated_size_pct *= 1.25
+                            sig_meta['sizing_boosts']['multiplier'] *= 1.25
+                            sig_meta['sizing_boosts']['capex_mult'] = \
+                                sig_meta['sizing_boosts'].get('capex_mult', 1.0) * 1.25
+                            sig_meta['sizing_boosts']['reasons'].append(
+                                'wyckoff_phase_C_accum (1.25x capex)')
+
                 # Step 5: Execute allocations
                 for intent in intents:
                     sig = intent.signal
@@ -1458,6 +1476,8 @@ class StandaloneBacktestEngine:
 
         # Create position
         pos_id = f"{direction}_{archetype}_{int(timestamp.timestamp())}"
+        if (self.config.get('cooldown_mode') == 'arm_on_entry'):
+            self.engine.arm_cooldown(archetype, bar_idx)
         self.positions[pos_id] = TrackedPosition(
             position_id=pos_id,
             archetype=archetype,

--- a/bin/live/live_feature_computer.py
+++ b/bin/live/live_feature_computer.py
@@ -1601,6 +1601,11 @@ class LiveFeatureComputer:
                 'sm_st_max_count': 2,       # break ST self-loop
                 'sm_spring_tolerance': 0.01,
                 'sm_ut_tolerance': 0.01,
+                # M2 (Schematic #2) SHADOW phase: wyckoff_phase_dir reads 'C'
+                # inside a qualified accumulation without touching events/
+                # scores/fusion (2026-08-04; consumed only by the config-gated
+                # wyckoff_phase_boost)
+                'sm_m2_context_only': True,
             }
             buf_copy = detect_all_wyckoff_events(buf_copy, cfg=_CFG_1H, htf_context=htf_context_4h)
             last = buf_copy.iloc[-1]

--- a/bin/live/v11_shadow_runner.py
+++ b/bin/live/v11_shadow_runner.py
@@ -1333,6 +1333,10 @@ class V11ShadowRunner:
             abr = features.get('alt_basket_ret_4h', None)
             if abr is not None and abr == abr:
                 s.metadata['alt_basket_ret_4h'] = float(abr)
+            # Wyckoff phase-C accumulation context for Boost 6 (validated 2026-08-04)
+            pdir = features.get('wyckoff_phase_dir', None)
+            if isinstance(pdir, str) and pdir:
+                s.metadata['wyckoff_phase_dir'] = pdir
 
         # Step 4: Portfolio allocation (bypass duplicate check in data-collection mode)
         if self.bypass_threshold:
@@ -1430,6 +1434,23 @@ class V11ShadowRunner:
                         f'local_flush_breadth alt4h={float(abr):+.3f} (1.25x capex)')
                     logger.info(f"[BREADTH_BOOST] wick_trap alt4h={float(abr):+.3f} "
                                 f"→ 1.25x capex sizing ({intent.allocated_size_pct:.3f})")
+
+            # Boost 6: Wyckoff phase-C accumulation context (validated 2026-08-04:
+            # C_accum long entries PF 2.07/1.50 train/hold vs 1.16/1.09 outside;
+            # battery train +$8.6K DD better, hold +$769; shadow-phase columns,
+            # zero fusion leakage). ANY long archetype.
+            if ((self.config.get('wyckoff_phase_boost') or {}).get('enabled')
+                    and intent.signal.direction == 'long'):
+                pdir = sig_meta.get('wyckoff_phase_dir', None)
+                if isinstance(pdir, str) and pdir == 'C_accum':
+                    intent.allocated_size_pct *= 1.25
+                    sig_meta['sizing_boosts']['multiplier'] *= 1.25
+                    sig_meta['sizing_boosts']['capex_mult'] = \
+                        sig_meta['sizing_boosts'].get('capex_mult', 1.0) * 1.25
+                    sig_meta['sizing_boosts']['reasons'].append(
+                        'wyckoff_phase_C_accum (1.25x capex)')
+                    logger.info(f"[WYCKOFF_PHASE_BOOST] {intent.signal.archetype_id} "
+                                f"C_accum → 1.25x capex sizing ({intent.allocated_size_pct:.3f})")
 
         # Update signal tracking for portfolio rejections
         for rej in rejections:

--- a/configs/champion/champion_liquidity_sweep.json
+++ b/configs/champion/champion_liquidity_sweep.json
@@ -64,7 +64,8 @@
     "trap_within_trend",
     "volume_fade_chop",
     "whipsaw",
-    "wick_trap"
+    "wick_trap",
+    "hob_reaction"
   ],
   "_disabled_archetypes_note": "2026-03-06: PRODUCTION MODE. bypass_threshold=false. 8 calibrated archetypes enabled, 9 disabled. Data collection mode (79 trades, 33% WR, -$4.5K) proved bypass is catastrophic.",
   "_calibrated_archetypes": [

--- a/configs/champion_paper.json
+++ b/configs/champion_paper.json
@@ -293,5 +293,9 @@
     "enabled": true,
     "_note": "validated 2026-08-01: LOCAL-flush 1.25x capex (train +$11.3K, holdout +$3.1K on stack)"
   },
-  "_exodus_note": "validated 2026-08-02: wick_trap refuses GLOBAL-flush + stables-rotation entries (train 1.36->1.56, holdout 1.26->1.51, DD down both)"
+  "_exodus_note": "validated 2026-08-02: wick_trap refuses GLOBAL-flush + stables-rotation entries (train 1.36->1.56, holdout 1.26->1.51, DD down both)",
+  "wyckoff_phase_boost": {
+    "enabled": true,
+    "_note": "Boost 6 (2026-08-04): C_accum long context 1.25x capex \u2014 validated co-move (train +$8.6K DD better, hold +$769); shadow phase, zero fusion leakage"
+  }
 }

--- a/docs/knowledge/all_seeing_eye_spec_v1.md
+++ b/docs/knowledge/all_seeing_eye_spec_v1.md
@@ -1,0 +1,69 @@
+# The All-Seeing Eye — Architecture Spec v1 (2026-08-05, DRAFT for user sign-off)
+
+One HTF authority that reads the market's story top-down and scales conviction across
+the entire book. Design is constrained by BOTH evidence bases: Wyckoff_Insider's
+actual mechanics (wyckoff_audit.md addenda 6-11) and our own validation history
+(boosts 6/6, filters 0/9, full-story standalone mechanization 0/4).
+
+## Core principle (source + evidence agree)
+The eye is a **SIZE DIAL with tiers, never a hard gate**. WI's own system: against-HTF
+= tactical size only; full size only after model confirmation. Our history: every
+veto-style filter failed; every sizing dial passed. The eye SCALES; it does not veto.
+
+## The state machine (per timeframe: 1D primary, 1W secondary; body-close semantics)
+States (WI's operative set):
+1. IN_RANGE          — default; HTF range boundaries from confirmed body-close extremes
+                       ("HTF range until proven otherwise"); track premium/discount
+2. MANIPULATION      — wick(s) beyond a boundary WITHOUT body close (sweep). Explicitly
+                       NOT a bias flip; arms reversal attention (feeds M1/M2 watch)
+3. MODEL_FORMING     — M1/M2 accumulation or distribution developing at an extreme
+                       (we already detect: phase machine + M2 path + spring/LPS events)
+4. CONFIRMED_BREAK   — real candle-BODY close beyond the range + acceptance (holds,
+                       does not immediately re-enter). Direction-tagged.
+5. TRENDING          — post-break with successful retest/LPS. Direction-tagged.
+Transitions: wick≠flip; body close + acceptance = flip; completed M2 (LPS+MSS) at an
+extreme may shift LOCAL bias pre-break (WI rule). Early invalidation: absence of the
+expected model at the extreme within a time window is itself a state signal.
+
+## Output surface (features on the 1H grid, causal, closed-HTF-bar discipline)
+- eye_state_1d / eye_state_1w  (enum above)
+- eye_dir (accum/bull vs dist/bear vs neutral), eye_location (premium/discount pct)
+- eye_conviction_tier: ALIGNED_CONFIRMED > ALIGNED_FORMING > NEUTRAL > COUNTER
+  (entry direction vs eye_dir, with MODEL_FORMING/CONFIRMED distinctions)
+
+## Sizing policy (the dial — pre-registered mapping, each rung validated separately)
+- ALIGNED_CONFIRMED: 1.25x (extends the validated C_accum boost pattern; capex-scoped)
+- ALIGNED_FORMING:   1.10x (small, must earn its own co-move pass)
+- NEUTRAL:           1.00x (base risk — today's behavior)
+- COUNTER:           0.75x (the "scalp tier"; DOWN-dial — this is the risky rung given
+                     filters-0/9; validated LAST, shipped only on its own co-move pass)
+Junk-book scope: DECISION PENDING (user) — whether the 13 unvalidated archetypes fall
+under the eye's authority or stay exempt at full size for data collection.
+
+## Validation ladder (no big-bang; every step gated like the C_accum boost was)
+P1. FEATURES: build the state machine as a registry-style causal feature pass
+    (patch-vNN pattern); truncation no-repaint tests; sanity distributions;
+    spot-check against WI's labeled charts (the ground-truth batch).
+P2. STAGE-1 DESCRIPTIVE (the gate): split existing champion entries by
+    eye_conviction_tier — tier ordering must hold in BOTH eras (train + holdout)
+    for the tiers to earn a build. If ordering fails → stop, report, redesign.
+P3. UP-DIALS: wire ALIGNED_* boosts (mirror Boost 6 pattern), bit-identical OFF
+    control, co-move battery per rung. Ship rungs that pass; drop rungs that fail.
+P4. DOWN-DIAL: COUNTER 0.75x tested alone, same protocol, explicit awareness that
+    this is filter-adjacent (history 0/9) — expected to fail honestly unless the
+    eye's read is genuinely better than the old blanket filters.
+P5. LIVE: mirror to v11_shadow_runner (parity tests — the step that catches
+    silent-never-fires), deploy ONLY on explicit user go, watch composition.
+
+## What the eye replaces / absorbs (coherence, not addition)
+Absorbs over time: wyckoff_phase_boost (becomes ALIGNED_CONFIRMED rung), breadth/
+rotation context (candidate CONFIRMING inputs to eye_dir), the parked HTF ideas
+(Bojan∩accumulation as a P3+ rung once live n suffices). The CMI regime system stays
+orthogonal (risk plumbing), untouched — no fusion changes anywhere (Lesson #54).
+
+## Honest priors
+- Each rung individually is boost-shaped (good prior); the COUNTER rung is not.
+- The state machine's transition rules are mechanizations of discretionary reads —
+  the ground-truth charts constrain them, but "acceptance" and range-boundary choice
+  carry residual judgment we may mechanize wrong; P2's both-era gate is the guard.
+- Junk-book authority is a user decision with a real trade-off (data vs coherence).

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -276,3 +276,31 @@ real; story-ENTRY is solved by existing archetypes; story-EXIT (ride the markup)
 the unsolved discretion gap → exactly WI questions #1 (TT/profit-taking formula),
 #2 (failed accumulations), #6 (failed-LPS handling). Do NOT retune exits on this
 rejected identity. Full-story mechanization now 0/3.
+
+### 2026-08-05 addendum 6 — WI execution intel (user-sourced): the missing exit organ
+
+Answers to the 7 questions (direct + labeled inference). The prize is his EXECUTION
+recipe, which maps 1:1 onto why wyckoff_campaign v1 (and PO3-orch) bled:
+1. **Exits (pre-mapped, banked, derisked):** TT defined IN ADVANCE (measured move /
+   "2X" projection of the range). TP1 partial (~40% observed), then SL moves UNDER the
+   newly-created LPS/structure (derisk to ~1/10), core runner held to full TT. Does
+   NOT trail LTF structure once TT is mapped. "Clear invalidation, clear target."
+2. **Failed accumulations:** near-zero public post-mortems (survivorship). Invalidation
+   tells (inferred): no MSS/acceptance after LPS/spring; close outside range/DL; HTF
+   flip. Failure = wait for the next (deeper) structure, not force the thesis.
+3. **Which range:** HTF range first ("HTF range until proven otherwise"), at HTF POI /
+   discount, with a clean Wyckoff (esp. M2) forming INSIDE it and room to the opposite
+   side. Duration matters less than developed phases.
+4. **Phase-C confirmation = ACCEPTANCE, not the event bar:** "Market structure break on
+   LPS. That is the trade." Waits for closes, sometimes days. (Explains our detector
+   firing Jun 26 vs his Jul 1 label.)
+5. **Phase-B maturity:** discretionary; more tests = quality; no public bar count.
+6. **Failed M2 LPS:** stop-out for the M2 TRADE (stop under the LPS structure — the
+   model's invalidation, NOT the deep range low); planned M1 re-entry lower may remain
+   if HTF intact. → per-model tight stops, layered demand.
+7. **Cross-market confluence (SMT/USDT.D):** conviction TIER, not hard requirement —
+   matches our boost framework exactly.
+DIAGNOSIS CONFIRMED: v1 campaign died on inverted geometry (deep stop, full size,
+R-ladder-capped winners). His geometry: tight model stop, banked partial, derisked
+runner to a pre-mapped structural TT. → ONE pre-registered v2 with WI-faithful
+execution (acceptance entry, LPS-structure stop, TP1+derisk+runner-to-TT).

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -304,3 +304,33 @@ DIAGNOSIS CONFIRMED: v1 campaign died on inverted geometry (deep stop, full size
 R-ladder-capped winners). His geometry: tight model stop, banked partial, derisked
 runner to a pre-mapped structural TT. → ONE pre-registered v2 with WI-faithful
 execution (acceptance entry, LPS-structure stop, TP1+derisk+runner-to-TT).
+
+### 2026-08-05 addendum 7 — WI batch 2: execution mechanics DECODED (direct evidence)
+
+**#8 selectivity:** no exact number published; "When not trading is the edge"; campaign
+trades = few high-conviction swings/year + scalps inside their ranges. Our ~950
+trades/5y is confirmed off-scale vs the source methodology.
+**#9 PO3 (VERBATIM): "A valid PO3 needs three things: A defined range. An aggressive
+break of that range. A Wyckoff inside the manipulation phase."** Never standalone. Our
+5x-rejected bare PO3 was structurally invalid by his own definition — diagnosis confirmed.
+
+**Ambiguities RESOLVED (direct quotes):**
+1. **Entry = return-to-zone (RTZ) after the MSS-on-LPS confirms** — "Return to zone
+   inside the range. LPS + Bojan. Market structure break on LPS. That is the trade."
+   MSS confirms; preferred fill is the retest back into the zone, not the breakout close.
+2. **Post-TP1 stop = UNDER THE CREATED LPS (structure anchor, NOT breakeven)** — gold
+   trade: "TP1 40%. SL movement under created LPS. Position fully derisked 1/10";
+   "TP by first supply or LTF bojan high to derisk SL same place not entry". One-step
+   structure trail anchored at the key created LPS; not a continuous every-higher-low trail.
+3. **TT** = pre-computed measured-move-style projection tied to the range/M2 ("2X"),
+   often BEYOND the plain range high/low, precise to decimals (74,384.7) — exact
+   formula still not public. Partials happen earlier at supply zones / Bojan highs;
+   core runner held to TT.
+
+**From the charts (gold 2H Jul-2026 + BTC 2H Dec-2025):** TP1 anchor = FIRST OPPOSING
+SUPPLY ZONE (structural, not an R-multiple). "UNF" (unfinished) W/M/5D candle levels
+act as magnets/targets ("M UNF fixed on demand", "UNF 5D 86,147"). Level vocabulary in
+active use: MM supply, M1 POI, HPS POI zone, inducement level, weekend $$$ (liquidity),
+timeframe-scoped Bojan zones ("3D Bojan + M Bojan + 6M Bojan" confluence at one price).
+Implication for v2 exits: TP1 should anchor to the nearest opposing structural zone
+(swing_high/supply), stop trails under the post-entry created LPS — both codable.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -334,3 +334,35 @@ active use: MM supply, M1 POI, HPS POI zone, inducement level, weekend $$$ (liqu
 timeframe-scoped Bojan zones ("3D Bojan + M Bojan + 6M Bojan" confluence at one price).
 Implication for v2 exits: TP1 should anchor to the nearest opposing structural zone
 (swing_high/supply), stop trails under the post-entry created LPS — both codable.
+
+### 2026-08-05 addendum 8 — WI batch 3 (final): Bojan/UNF decoded to public limit
+
+**Bojan** ("Bojan = multi-timeframe precision"; source influence @Bojan_618 — wick
+quality, opens without wicks that get "fixed", early/ugly lows):
+- M1 Bojan = highest wick tags major liquidity / MM supply-demand. M2 Bojan = same
+  structure connected to mid/HTF range highs/lows.
+- HIGHEST CONFLUENCE STACK (verbatim): M2 (third candle) + M1 (fourth candle) +
+  unfinished-candle push into liquidity + POC/Wyckoff + 0.5–0.618 fib.
+- Dual nature: bar pattern AND persistent timeframe-scoped zone ("6M Bojan low" lives
+  for months). Zone centered on the WICK TIP (body/open secondary).
+- INVALIDATION: close beyond it — and it CONVERTS to an unfinished candle ("Monthly
+  Bojan High invalidated. We now have a monthly unfinished candle.").
+- Grammar (observed): Bojan LOWS = demand/entry confluence + SL anchors ("SL under
+  45M Bojan low"); Bojan HIGHS = TP anchors / short triggers.
+- NO public wick-% rule — our legacy bojan.py 70% threshold is OUR invention, not his.
+**UNF (unfinished)**: candle missing a proper wick on one side / incomplete extreme
+expected to be revisited ("fixed"). Tracked D+ (W/3W/5D/12M); prioritize HTF + those
+aligned with Bojan levels/range extremes. UNF + Bojan highs + TT = his target ladder.
+**TT formula**: NOT publicly recoverable (no worked example; decimals imply clean
+2-anchor calc). Treat any implementation as hypothesis.
+**RTZ**: zone = the LPS/Bojan demand zone or impulse origin; prefers return after MSS
+("MS break > Time displacement"); no chase of unreturned displacement; fill depth unquantified.
+**Sizing**: "2% risk setups" (matches our 2%); TP1 ~40% at first supply → SL under
+created LPS → residual risk ≈ 1/10 of initial ("fully derisked 1/10"); builds
+positions, no mechanical grid published.
+**Vocab**: DL/DL2 = custom range/deviation tool ("DL2 always overrules negative
+FIBS"); inducement = engineered trap level at MM zones; SMT = related-pair divergence
+(ETH/BTC, dominance) at swing pivots, legs/TF not fully specified; "$$$" ≈ liquidity
+(weak evidence); "6-candle type logic" = older range-construction rules, unrecovered.
+**Failed structures**: permanent survivorship gap — compensate by self-labeling
+broken ranges from raw history when building ground truth.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -366,3 +366,16 @@ FIBS"); inducement = engineered trap level at MM zones; SMT = related-pair diver
 (weak evidence); "6-candle type logic" = older range-construction rules, unrecovered.
 **Failed structures**: permanent survivorship gap — compensate by self-labeling
 broken ranges from raw history when building ground truth.
+
+### 2026-08-05 addendum 9 — v2 gate CLOSED: WI geometry does not rescue campaign entries
+
+Descriptive replay of all 100 reconstructed v1 episodes under the decoded WI execution
+(model stop = event-window low −0.25 ATR; TP1 40% at nearest resistance; runner
+derisked to ~1/10R; TT = swing_high_50; 168h cap): TRAIN n=57 PF 0.92 −$5,783;
+OOS-A n=25 PF 1.44 +$12,443; OOS-B n=18 PF 0.67 −$6,862. Geometry WORKED mechanically
+(avg win/loss flipped 0.37→1.7) but tighter stops cut WR to ~35% → net negative 2/3
+windows. DOUBLE-CONFIRMED: the raw C_accum+spring entry has no standalone edge under
+either geometry — it was never the exits. wyckoff_campaign v2 NOT built (gate did its
+job for ~0 cost). The campaign vision's validated expression remains: existing
+archetype entries + phase-context sizing (the boost). Caveat: TP1/TT proxies crude
+(dist_to_resistance/swing_high_50); insufficient to overturn a 2-of-3-negative gate.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -396,3 +396,25 @@ low blind — his usage is LPS+Bojan INSIDE an armed accumulation; the faithful 
 is Bojan-low ∩ C_accum, but the intersection cohort is likely n<10 → underpowered
 today; revisit when live data accumulates. Legacy test_wyckoff_events.py 5 failures
 confirmed PRE-EXISTING on main (Feb-2026 recalibration fixture debt, unrelated).
+
+### 2026-08-05 addendum 11 — WI batch 4 (final): HTF mechanics for the all-seeing eye
+
+**States (his operative set — NOT the rigid 4-phase schematic):** IN_RANGE (default:
+"HTF range until proven otherwise"), MANIPULATION (wick deviation of/inside range —
+explicitly NOT a bias flip), MODEL_FORMING (M1/M2 accum/dist at the extremes),
+CONFIRMED_BREAK (real candle-BODY structure beyond the range + acceptance),
+TRENDING (post-break + successful retest/LPS). Plus premium/discount location.
+Neutral until proven; "reacts to the model that is present."
+**Precedence:** HTF governs bias + SIZE; MTF/LTF may authorize only small tactical
+scalps before/against HTF confirmation. "No confirmation = no trade" (at size).
+**Bias flip rule:** real candle-BODY break beyond the HTF range (wick = manipulation,
+never a flip); Monthly/2W breaks weighted highest; acceptance vs rejection decides;
+a COMPLETED M2 (LPS + MSS) at the extreme can shift local bias pre-break.
+**Permission = DIAL (his own words' shape):** against-HTF → main size ~zero until
+confirmation, scalps allowed; full size only after Wyckoff confirmation. Soft gate
+for meaningful risk, dial for tactical risk. → matches our boosts-6/6 vs filters-0/9
+evidence EXACTLY: the source's architecture is size-tiers, not vetoes.
+**Early HTF-read invalidation:** ABSENCE of the expected model at the extreme is
+itself information (no M1/M2/LPS/Bojan forming); body-break against; acceptance on
+the wrong side; missing confluence (SMT/dominance silent); time-based expiry of the
+expected window. "Data points alone are not a trade."

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -169,3 +169,37 @@ event booleans were V14-era values all along; v20 stitch coerces them properly.
 5. **Ground truth**: his labels exist only as chart images. Transcribing 20-30
    (spring bar + range + outcome) = highest-leverage addition — would replace the
    granularity-mismatched consensus-14 harness.
+
+### 2026-08-04 addendum 2 — M2 DECODED + first real ground-truth recall test
+
+**CORRECTION to addendum 1 item 4: Model 2 IS publicly mechanizable.** His chart insets
+are the canonical **Accumulation Schematic #2 (Bogomazov/Pruden, WyckoffAnalytics)**:
+Phase A: PS → SC → AR → ST | Phase B: "ST in Phase B" (undercuts SC support = his
+"ST-B") | Phase C: **LPS above support — NO SPRING** | Phase D: LPS → SOS → BU/LPS |
+Phase E: markup. M1 = Schematic #1 (spring in phase C). His caption: "Not every
+accumulation has a spring. In Schematic #2, smart money absorbs supply more quietly."
+He confirms M2 usage with: SMT on the low, return-to-zone, LPS+Bojan, MSS on LPS.
+Fractal: same schematic on 15m BTC (8-day range), 3D/4D USDT.D (2-year range), 45m alts.
+
+**Ground truth v0 — transcribed from his BTC M2 chart (posted Jul 03 2026, Bybit 15m):**
+PS 06-25 ~$59.0K | SC 06-26 ~$57.9K | AR 06-26 ~$60.8K | ST 06-27 ~$58.3K |
+ST-B 07-01 ~$57.7K (undercuts SC) | LPS 07-01 ~$58.25K (Bojan 58,217-58,523) |
+SOS 07-02 ~$60.8K | BU/LPS 07-03 ~$59.6K. (Chart images archived from pbs.twimg.com;
+more transcribable M2 charts listed in the source thread.)
+
+**Recall test (fixed detector, production _CFG_1H, real Binance klines):**
+- 1H bars: ~0/8 — detector effectively blind at 1H to an 8-day structure (windows
+  are 15-50 bars; the range is 120+ 1H bars). phase_dir neutral throughout.
+- **4H bars: front half CAUGHT** — SC 06-25 conf 0.66 (his SC 06-26), AR conf 0.90,
+  ST twice, and phase_dir = A_accum for the ENTIRE structure (correct direction!).
+  Back half (ST-B / LPS / SOS): NOTHING.
+- **Structural cause of the back-half miss: our sequencer has NO phase-C LPS path** —
+  it only allows LPS *after* SOS (BU/LPS). In Schematic #2 the LPS comes BEFORE the
+  SOS. M2's signature moment is literally unrepresentable in the current state machine.
+
+**Next-upgrade queue (pre-registered studies, in order of evidence):**
+1. **M2 sequencer path**: allow ST-in-B (undercut without invalidation), phase-C LPS
+   from AR/ST states, SOS following LPS. All constituent detectors already exist.
+2. **HTF-native detection**: his structures live at 4H+ scale; 1H windows are myopic.
+   4H already catches phase A/B — supports the HTF-permission hierarchy (addendum 1).
+3. Expand ground truth from the remaining archived M2 charts (USDT.D 3D/4D series).

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -379,3 +379,20 @@ either geometry — it was never the exits. wyckoff_campaign v2 NOT built (gate 
 job for ~0 cost). The campaign vision's validated expression remains: existing
 archetype entries + phase-context sizing (the boost). Caveat: TP1/TT proxies crude
 (dist_to_resistance/swing_high_50); insufficient to overturn a 2-of-3-negative gate.
+
+### 2026-08-05 addendum 10 — Bojan/UNF registry: built, Stage-1 gate REJECTED
+
+Registry (engine/features/bojan_unf_registry.py, branch feat/bojan-unf-registry,
+9dc083c): 1D/3D/1W wick-extreme Bojan zones + UNF magnets + close-beyond→UNF
+conversion; causal (3-truncation no-repaint verified); sane counts (median 4
+concurrent active Bojan-lows). KEPT as research infrastructure.
+**Stage-1 gate FAILED**: near-Bojan-low champion long entries TRAIN PF 0.72 vs 1.24
+away (−$13.4K, damage in 2019/2021/2022 bear years — falling knives), HOLD PF 1.46
+vs 1.07 (bull tailwind) — Rule-9 sign-flip; regime-conditional, not structural.
+Target-ladder respect weak (winners stall within 1 ATR of overhead Bojan-high/UNF
+only 15%/12%). NO boost built (gate stopped it at descriptive cost).
+Noted for a possible future pre-registered study (NOT run): WI never buys a Bojan
+low blind — his usage is LPS+Bojan INSIDE an armed accumulation; the faithful test
+is Bojan-low ∩ C_accum, but the intersection cohort is likely n<10 → underpowered
+today; revisit when live data accumulates. Legacy test_wyckoff_events.py 5 failures
+confirmed PRE-EXISTING on main (Feb-2026 recalibration fixture debt, unrelated).

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -203,3 +203,30 @@ more transcribable M2 charts listed in the source thread.)
 2. **HTF-native detection**: his structures live at 4H+ scale; 1H windows are myopic.
    4H already catches phase A/B — supports the HTF-permission hierarchy (addendum 1).
 3. Expand ground truth from the remaining archived M2 charts (USDT.D 3D/4D series).
+
+### 2026-08-04 addendum 3 — M2 sequencer path BUILT, champion-gated OFF
+
+Implemented Schematic #2 in the state machine (states ACCUM_LPS_C / DISTRIB_LPSY_C,
+phase 'C' direction-aware; phase-B work required before the phase-C LPS; one per
+structure — first draft without these constraints exploded LPS 16→2,727 (170x);
+constrained: 16→452, ~53/yr). Tests: tests/test_wyckoff_m2_sequence.py (5, incl.
+default-off + straight-from-AR rejection). On WI's labeled BTC chart (4H): ONE
+phase-C LPS conf 0.93 + sustained C_accum through the full 8-day structure (V21
+store: C_accum coverage 2,859→11,147 bars).
+
+**Champion co-move (V21 = V20 + M2, champion_paper.json, position-level):**
+| store | train PF / PnL | hold PF / PnL |
+|---|---|---|
+| V18 (orig) | 1.193 / $98,535 | 1.028 / $2,867 |
+| V20 (fallback) | 1.192 / $97,566 | **1.114 / $12,159** |
+| V21 (+M2) | **1.219 / $110,609** | 1.066 / $7,001 |
+
+V21 beats V18 in BOTH windows, but vs the validated V20 baseline the M2 increment is
+**train +$13.0K / holdout −$5.2K** — the train-up/OOS-down gradient (Rule 9 fail).
+**VERDICT: sm_m2_path default OFF** (evidence-gated; code+tests kept, opt-in).
+V20 remains the candidate store-of-record; V21_M2 kept as research artifact.
+
+Open question for a future study: C_accum as a CONTEXT/bias feature (sizing boost
+when phase_dir=C_accum) rather than through fusion-score reshuffling — the failure
+mode here was fusion/dedup reshuffle, not the phase reading itself (which was
+CORRECT on WI's chart). Prior: boosts 5/5.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -148,3 +148,24 @@ event booleans were V14-era values all along; v20 stitch coerces them properly.
   TWT +$4.1K, LC +$2.7K, FC +$1.8K) while wick_trap gives back −$5.0K and spring
   −$1.9K (fusion/dedup reshuffle from repopulated wyckoff scores). Book-level and
   validated-side net positive; watch wick_trap live share after any deploy.
+
+### 2026-08-04 addendum — Wyckoff Insider's actual practice (user-sourced, public posts)
+
+1. **Springs do NOT always require a prior SC** — valid inside reaccumulation ranges
+   (mid-uptrend pauses) without a fresh climax. EXTERNALLY VALIDATES the
+   sm_no_context_fallback change. His practice ≈ "defined range + poke-and-recover",
+   suggesting a future refinement: range-existence gate (e.g. tf4h_coil / band
+   tightness) instead of unconditional no-context fallback.
+2. **Volume tells**: he prioritizes structural recovery + confluence (MSS, return-to-
+   zone, LPS+Bojan) over strict volume formulas. Entry safety ranking: Spring/Test
+   safest > Bojan-low-in-Spring (aggressive, high R:R) > LPS (riskier re-entry).
+3. **Timeframe hierarchy (clear)**: HTF (D/W) = range, bias, permission; MTF =
+   structure/Bojan/LPS refinement; LTF = trigger. Our fixed 0.5/0.3/0.2 MTF blend in
+   _get_wyckoff_score is reasonable but suboptimal vs HTF-permission-first gating.
+4. **Model 2 is NOT publicly mechanizable** — named schematic (return-to-zone, LPS+
+   Bojan, MSS on LPS, TT targets) with no bar-level public spec. Do NOT attempt to
+   rebuild mechanically (PO3-shell lesson). Our tf1d_wyckoff_m2_signal (~26% of bars)
+   provenance is fuzzy — treat with skepticism.
+5. **Ground truth**: his labels exist only as chart images. Transcribing 20-30
+   (spring bar + range + outcome) = highest-leverage addition — would replace the
+   granularity-mismatched consensus-14 harness.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -258,3 +258,21 @@ phase_dir=='C_accum', default OFF): battery on V22_CTX, champion_paper base:
 **VERDICT: PASS (co-move both eras; boosts now 6-for-6). Deploy-gated on user.**
 Caveats: hold boosted n=19 (<30, flagged); train −2 positions (capex margin
 consumption); DD hold +0.5pp minor.
+
+### 2026-08-05 addendum 5 — wyckoff_campaign standalone REJECTED (3rd full-story failure)
+
+S12 "wyckoff_campaign" (C_accum phase + spring/PTI confirmation entry, swing_low_50
+structural stop, Smart Exits V2, long-only) built on study/wyckoff-campaign (64f79a7),
+full pre-registered protocol. VERDICT: REJECT — TRAIN −$3,825 PF 0.72 (bear years
+bleed); OOS-A +$787 (n=7, thin), OOS-B +$4,280 PF 2.27 (n=10); pooled PF 1.07; in-book
+ZERO trades (neutral-weight fusion never clears the champion threshold, $0 delta).
+94% orthogonal to spring/wick_trap entries — not redundancy; the fresh entries are
+simply not good enough alone. FAILURE MECHANISM = exit/stop geometry AGAIN: wide
+structural stop → avg loss $1,096 vs avg win $401 with R-ladder-capped winners (same
+killer as PO3-orchestration). THE SPLIT VERDICT vs the validated boost: C_accum
+context makes EXISTING archetype entries better (boost passed, co-move) but does NOT
+make raw spring-event entries inside C_accum a standalone edge. Chapter-awareness is
+real; story-ENTRY is solved by existing archetypes; story-EXIT (ride the markup) is
+the unsolved discretion gap → exactly WI questions #1 (TT/profit-taking formula),
+#2 (failed accumulations), #6 (failed-LPS handling). Do NOT retune exits on this
+rejected identity. Full-story mechanization now 0/3.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -230,3 +230,31 @@ Open question for a future study: C_accum as a CONTEXT/bias feature (sizing boos
 when phase_dir=C_accum) rather than through fusion-score reshuffling — the failure
 mode here was fusion/dedup reshuffle, not the phase reading itself (which was
 CORRECT on WI's chart). Prior: boosts 5/5.
+
+### 2026-08-04 addendum 4 — wyckoff_phase_boost VALIDATED (the correct test)
+
+User correction applied: judging M2 detection through fusion-mediated book PnL was
+the wrong instrument (Lesson #54 — fusion is noise). Correct instrument = direct
+predictive test + boost channel (boosts 5/5).
+
+**Direct test:** V20-champion LONG entries inside phase-C accumulation: PF 2.07
+train / 1.50 hold vs 1.16 / 1.09 outside (n=52/19, co-move both eras). Bar-level
+C_accum alone sign-flips across eras → qualifier, not standalone predictor.
+
+**Architecture:** `sm_m2_context_only` SHADOW phase — M2 state machine drives
+wyckoff_phase_dir ONLY; no event emission, no state mutation. Guard-verified:
+V22_CTX store differs from V20 in ONLY {phase_abc, phase_dir, sequence_position};
+all 29 event/score columns bit-identical; C_accum on the same 11,147 bars as full
+M2. (Guard also caught + reverted an unintended legacy widening: repeat-BU/LPS
+validation had leaked into every score column via replay. Tests were green — only
+the byte-level store comparison saw it.)
+
+**Boost 6** (`wyckoff_phase_boost`, 1.25x + scoped capex, ANY long archetype when
+phase_dir=='C_accum', default OFF): battery on V22_CTX, champion_paper base:
+- CONTROL: boost-OFF bit-identical to V20 champion runs (1738/596 rows) — clean attribution
+- TRAIN: PF 1.192→1.208, $97,566→$106,175 (+$8,609), DD −30.7→−29.8 (better)
+- HOLD:  PF 1.114→1.120, $12,159→$12,928 (+$769), DD −16.9→−17.4 (−0.5pp)
+- Mechanical sanity: hold delta +$769 ≈ 25% × the $3.1K C_accum-entry PnL (exact)
+**VERDICT: PASS (co-move both eras; boosts now 6-for-6). Deploy-gated on user.**
+Caveats: hold boosted n=19 (<30, flagged); train −2 positions (capex margin
+consumption); DD hold +0.5pp minor.

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -102,3 +102,49 @@
 - Before: tf1d_wyckoff_score=0.5 constant, M1/M2=0, tf4h missing
 - After: Real computed values from resampled 4H/1D Wyckoff detection
 - Impact: PF 1.28→1.38, Return +44.9%→+78.8%, Sharpe 1.39→1.59
+
+---
+
+## 2026-08-04 — spring_b look-ahead fix + no-context fallback + directional phase (V20)
+
+**Bug (fixed):** `detect_spring_type_b` read future closes (`close.shift(-offset)`,
+offset 0..2) with a "shift result back" comment whose shift was never written —
+batch runs repainted; live could not reproduce (future bars absent → NaN). Fixed to
+the spring_a/UT candidate/confirm pattern: fires on the confirmation bar, causal.
+Guard: `tests/test_wyckoff_causality.py` (batch-vs-truncated-walk agreement for all
+event columns — failed on old code exactly at wyckoff_spring_b; 4/4 pass post-fix).
+
+**Sparsity root cause (fixed):** the state machine discarded any spring/UT without a
+previously validated SC→AR structure, and SC's triple-extreme gate (volume_z>2.5 AND
+range_pos<0.2 AND range_z>1.5) almost never validates one. Springs: 9 events / 8.5y.
+Fix: extended the sanctioned SOS/SOW no-context fallback (fire at 0.5x confidence,
+`sm_no_context_fallback`, default ON) to spring_a/spring_b/UT/UTAD.
+Batch counts: spring_a 9→77, spring_b 54→169 (now causal), ut/utad 6→19; all other
+detectors bit-unchanged. ~29 springs/year — populated, no explosion.
+
+**Directional phase (new):** `wyckoff_phase_dir` ('C_accum'/'C_distrib'/...) +
+`wyckoff_context` exported — the bare letter conflates accumulation/distribution
+(both ACCUM_SPRING and DISTRIB_UT map to 'C'; only ~37% of C/D bars were
+accumulation-direction). mutual_exclusion was already default-on (2026-06 fix).
+
+**Consensus-14 harness (honesty):** label-level recall 0/14 → 0/14. The curated
+events are DAILY-scale structures; on 1H the engine correctly labels e.g. the
+2024-08-05 crash low ($49,000) as SC, not Spring. Even V12's columns score only
+4/14 today. Harness has a granularity mismatch — needs 1H-scale ground truth.
+Event-agnostic: 8/14 windows contain validated events (unchanged), with new
+spring/UT detections inside 2 of them.
+
+**V20 store:** `BTC_1H_FEATURES_V20_WYCKOFF.parquet` = V18_ROTATION + wyckoff
+family regenerated via live replay (`scripts/rebuild/patch_v20_wyckoff.py`, 6
+chunks; store==live parity by construction). Store validator: 8 PASS / 0 FAIL.
+NOTE: the v15-pattern stitch dropped object-dtype event bools — meaning V15/V18's
+event booleans were V14-era values all along; v20 stitch coerces them properly.
+
+**Champion co-move (V18 vs V20, champion_paper.json, position-level):**
+- TRAIN 2018-22: 796→794 pos, PF 1.193→1.192, $98,535→$97,566 (−1.0%, noise), DD −29.8→−30.7%
+- HOLDOUT 2025-26: 255→263 pos, PF 1.028→1.114, $2,867→**$12,159** (+$9.3K), DD −16.8→−16.9%
+- VERDICT: PASS (train within noise, holdout strongly improved) → fallback ships ON.
+- Composition caveat: holdout gain is bleeders bleeding less (liquidity_sweep +$4.9K,
+  TWT +$4.1K, LC +$2.7K, FC +$1.8K) while wick_trap gives back −$5.0K and spring
+  −$1.9K (fusion/dedup reshuffle from repopulated wyckoff scores). Book-level and
+  validated-side net positive; watch wick_trap live share after any deploy.

--- a/engine/archetypes/archetype_instance.py
+++ b/engine/archetypes/archetype_instance.py
@@ -55,6 +55,14 @@ DERIVED_FEATURES = {
         (_safe_float(f.get('high', 0)) - max(_safe_float(f.get('open', 0)), _safe_float(f.get('close', 0)))) / max(abs(_safe_float(f.get('close', 0)) - _safe_float(f.get('open', 0))), 0.01),
         10.0
     ),
+    # Whipsaw-long resurrection study (2026-08-02): exact mirror of
+    # upper_wick_body_ratio for the long-side lower-wick rejection gate.
+    # Inert unless a YAML gate references 'derived:lower_wick_body_ratio'
+    # (no production YAML does — used only by the study variant YAML dir).
+    'lower_wick_body_ratio': lambda f: min(
+        (min(_safe_float(f.get('open', 0)), _safe_float(f.get('close', 0))) - _safe_float(f.get('low', 0))) / max(abs(_safe_float(f.get('close', 0)) - _safe_float(f.get('open', 0))), 0.01),
+        10.0
+    ),
     # Phase 2: Strategy notebook derived features
     'wyckoff_in_accumulation': lambda f: str(f.get('wyckoff_context', '')).lower() == 'accumulation',
     'wyckoff_in_distribution': lambda f: str(f.get('wyckoff_context', '')).lower() == 'distribution',
@@ -892,7 +900,11 @@ class ArchetypeInstance:
 
         # Update cooling period state
         if current_bar_idx is not None:
-            self.last_signal_bar = current_bar_idx
+            # Cooldown study 2026-08-02: legacy arms on SIGNAL (even if the
+            # signal is later deduped/blocked — audited as unintended).
+            # 'arm_on_entry'/'off' modes defer/skip arming (engine-controlled).
+            if not getattr(self, 'defer_cooldown_arm', False):
+                self.last_signal_bar = current_bar_idx
             logger.debug(f"[SIGNAL] {self.name} fired at bar {current_bar_idx}, next available at {current_bar_idx + self.cooling_period_bars}")
 
         # Compute domain scores for metadata

--- a/engine/archetypes/exit_logic.py
+++ b/engine/archetypes/exit_logic.py
@@ -914,20 +914,61 @@ class ExitLogic:
             scale_levels = rules.get('scale_out_levels', [0.5, 1.0, 2.0])
             scale_pcts = rules.get('scale_out_pcts', [0.33, 0.2, 0.3])
 
+        # ------------------------------------------------------------------
+        # MANCINI LEVEL-LADDER STUDY (study-gated; default absent = legacy)
+        #
+        # PRE-REGISTERED RULE (committed BEFORE any battery run; ONE design,
+        # no grids, no post-hoc tuning of any constant below):
+        #   - Active only when rules['level_ladder'] is truthy AND the
+        #     position is LONG. Shorts and all other archetypes: legacy.
+        #   - On the FIRST exit-check bar of a position (entry + 1 bar,
+        #     point-in-time trailing features only), build a FROZEN ladder:
+        #       initial_risk = entry_price - stop_loss
+        #       candidates   = {prior_day_high, swing_high_50,
+        #                       round_number_above} from that bar, kept only
+        #       if finite AND price >= entry + 0.25 * initial_risk.
+        #   - For each rung k in legacy order (R-multiple L_k, R-distance
+        #     D_k = L_k * initial_risk): among UNUSED candidates whose
+        #     distance d = (price - entry) lies within [0.7*D_k, 1.5*D_k],
+        #     pick the one minimizing |d - D_k|. If found, that candidate is
+        #     consumed and the rung's trigger becomes R'_k = d/initial_risk
+        #     (i.e. the rung fires at the LEVEL price). Else R'_k = L_k
+        #     (legacy R-price).
+        #   - Everything else is unchanged: rung fires when unrealized_r >=
+        #     trigger (close-based evaluation, close-price fill), exit_pct
+        #     unchanged, executed_scale_outs still records the LEGACY key
+        #     L_k (keeps runner/trailing bookkeeping identical), one rung
+        #     per bar, rungs evaluated in legacy order.
+        #   - If level features are missing from the bar, fall back to
+        #     legacy triggers for that position.
+        # ------------------------------------------------------------------
+        ll_map = None
+        if rules.get('level_ladder') and position.direction == 'long':
+            ll_map = self._get_level_ladder_triggers(bar, position, scale_levels, exit_context)
+
         # Track which scale-outs already executed
         executed_scales = position.metadata.get('executed_scale_outs', [])
 
         # Check each scale level in order
-        for level, pct in zip(scale_levels, scale_pcts):
-            if unrealized_r >= level and level not in executed_scales:
-                # Mark this scale level as executed
+        for i, (level, pct) in enumerate(zip(scale_levels, scale_pcts)):
+            trigger_r = level
+            ll_tag = ""
+            if ll_map is not None:
+                trigger_r, src_name, src_price = ll_map[i]
+                if src_name is not None:
+                    ll_tag = f" [LL:mapped {src_name}@{src_price:.0f} r={trigger_r:.2f}]"
+                else:
+                    ll_tag = " [LL:legacy]"
+
+            if unrealized_r >= trigger_r and level not in executed_scales:
+                # Mark this scale level as executed (legacy key for bookkeeping)
                 executed_scales.append(level)
                 position.metadata['executed_scale_outs'] = executed_scales
 
                 return ExitSignal(
                     exit_type=ExitType.PROFIT_TARGET.value,
                     exit_pct=pct,
-                    reason=f"Scale-out at {level:.1f}R (exit {pct*100:.0f}%)",
+                    reason=f"Scale-out at {level:.1f}R (exit {pct*100:.0f}%){ll_tag}",
                     confidence=1.0,
                     metadata={**exit_context, 'scale_level': level}
                 )
@@ -965,6 +1006,79 @@ class ExitLogic:
                     )
 
         return None
+
+    def _get_level_ladder_triggers(
+        self,
+        bar: pd.Series,
+        position: "Position",
+        scale_levels: list,
+        exit_context: Dict,
+    ):
+        """MANCINI LEVEL-LADDER STUDY helper (see pre-registered rule in
+        _check_profit_targets). Builds the frozen rung->trigger map for a LONG
+        position on its first exit-check bar and caches it on the ExitLogic
+        instance (position adapters are rebuilt every bar, so instance-level
+        caching keyed by position identity is the persistence mechanism).
+
+        Returns:
+            List of (trigger_r, src_name_or_None, src_price) per rung, or
+            None if the ladder cannot be built (missing features / zero risk)
+            — caller then uses pure legacy triggers.
+        """
+        cache = getattr(self, '_ll_ladder_cache', None)
+        if cache is None:
+            cache = self._ll_ladder_cache = {}
+
+        key = (position.entry_time, position.entry_price,
+               exit_context.get('archetype'))
+        if key in cache:
+            cached = cache[key]
+            # Guard against ladder-length mismatch (config change mid-run: impossible in practice)
+            return cached if (cached is None or len(cached) == len(scale_levels)) else None
+
+        entry = position.entry_price
+        initial_risk = abs(entry - position.stop_loss)
+        if not (initial_risk > 0):
+            cache[key] = None
+            return None
+
+        # Candidate levels from the current (first-check) bar — frozen hereafter
+        candidates = []
+        for name in ('prior_day_high', 'swing_high_50', 'round_number_above'):
+            val = bar.get(name) if hasattr(bar, 'get') else None
+            if val is not None and val == val:  # NaN guard
+                price = float(val)
+                if price >= entry + 0.25 * initial_risk:
+                    candidates.append([name, price, False])  # [name, price, used]
+
+        if not candidates:
+            # No usable level features / no level above the floor: legacy triggers
+            result = [(float(lvl), None, 0.0) for lvl in scale_levels]
+            cache[key] = result
+            return result
+
+        result = []
+        for lvl in scale_levels:
+            d_k = float(lvl) * initial_risk
+            best = None
+            best_dev = None
+            for cand in candidates:
+                if cand[2]:
+                    continue  # already consumed by a lower rung
+                d = cand[1] - entry
+                if 0.7 * d_k <= d <= 1.5 * d_k:
+                    dev = abs(d - d_k)
+                    if best_dev is None or dev < best_dev:
+                        best = cand
+                        best_dev = dev
+            if best is not None:
+                best[2] = True  # consume
+                result.append(((best[1] - entry) / initial_risk, best[0], best[1]))
+            else:
+                result.append((float(lvl), None, 0.0))
+
+        cache[key] = result
+        return result
 
     def _check_time_based(
         self,

--- a/engine/integrations/isolated_archetype_engine.py
+++ b/engine/integrations/isolated_archetype_engine.py
@@ -140,6 +140,10 @@ class IsolatedArchetypeEngine:
                 config_dict['hard_gates'] = gates
             archetype_config = self._convert_to_archetype_config(config_dict)
             self.archetypes[name] = ArchetypeInstance(archetype_config)
+            # cooldown_mode: 'legacy' (arm on signal, default) |
+            # 'arm_on_entry' (caller arms via arm_cooldown after fill) | 'off'
+            _cd_mode = (self.config or {}).get('cooldown_mode', 'legacy')
+            self.archetypes[name].defer_cooldown_arm = _cd_mode != 'legacy'
             logger.info(
                 f"  Initialized: {name} ({config_dict['direction']}) - "
                 f"Fusion W={config_dict['fusion_weights']['wyckoff']:.2f}"
@@ -657,6 +661,13 @@ class IsolatedArchetypeEngine:
             return kept
 
         return signals
+
+    def arm_cooldown(self, archetype_id: str, bar_index: int) -> None:
+        """Arm an archetype's cooldown (used by cooldown_mode='arm_on_entry'
+        after a signal actually becomes a position)."""
+        inst = self.archetypes.get(archetype_id)
+        if inst is not None:
+            inst.last_signal_bar = bar_index
 
     def get_signals(
         self,

--- a/engine/wyckoff/events.py
+++ b/engine/wyckoff/events.py
@@ -224,6 +224,19 @@ class WyckoffStateMachine:
                         if raw_events.get('spring_b', False):
                             validated['spring_b'] = True
                         self.state = WyckoffState.ACCUM_SPRING
+            elif (self.context == WyckoffContext.NONE
+                  and self.cfg.get('sm_no_context_fallback', True)):
+                # No validated SC->AR structure exists — SC's triple-extreme gate
+                # makes that the norm, which starved springs to near-zero. Mirror
+                # the SOS/SOW no-context fallback: keep the raw detector event at
+                # half confidence instead of discarding it. State is NOT advanced
+                # (no structure to advance).
+                if raw_events.get('spring_a', False):
+                    validated['spring_a'] = True
+                    modifiers['spring_a'] = 0.5
+                if raw_events.get('spring_b', False):
+                    validated['spring_b'] = True
+                    modifiers['spring_b'] = 0.5
 
         # SOS: Requires accumulation context, or fires with reduced confidence when no context
         if raw_events.get('sos', False):
@@ -281,6 +294,15 @@ class WyckoffStateMachine:
                         if raw_events.get('utad', False):
                             validated['utad'] = True
                         self.state = WyckoffState.DISTRIB_UT
+            elif (self.context == WyckoffContext.NONE
+                  and self.cfg.get('sm_no_context_fallback', True)):
+                # Mirror of the spring no-context fallback (see accumulation path).
+                if raw_events.get('ut', False):
+                    validated['ut'] = True
+                    modifiers['ut'] = 0.5
+                if raw_events.get('utad', False):
+                    validated['utad'] = True
+                    modifiers['utad'] = 0.5
 
         # SOW: Requires distribution context, or fires with reduced confidence when no context
         if raw_events.get('sow', False):
@@ -330,6 +352,22 @@ class WyckoffStateMachine:
     def get_context_str(self) -> str:
         """Return context string"""
         return self.context.value
+
+    def get_phase_dir(self) -> str:
+        """Directional phase label: phase letter + structure direction.
+
+        The plain letter conflates accumulation and distribution — e.g. both
+        ACCUM_SPRING and DISTRIB_UT map to 'C' in get_phase(). Consumers that
+        need direction should read this (or pair phase with wyckoff_context).
+        """
+        phase = self.get_phase()
+        if phase == 'neutral':
+            return 'neutral'
+        if self.context == WyckoffContext.ACCUMULATION:
+            return f"{phase}_accum"
+        if self.context == WyckoffContext.DISTRIBUTION:
+            return f"{phase}_distrib"
+        return phase
 
 
 @dataclass
@@ -954,29 +992,36 @@ def detect_spring_type_b(df: pd.DataFrame, cfg: dict) -> Tuple[pd.Series, pd.Ser
     breakdown_pct = (rolling_low - df['low']) / (rolling_low + 1e-9)
     shallow_break = (breakdown_pct > breakdown_min) & (breakdown_pct < breakdown_max)
 
-    # Multi-bar recovery: close recovers above lower quartile within recovery_bars
-    # Check if ANY bar in the next recovery_bars window recovers
-    if recovery_bars > 1:
-        recovery_check = pd.Series(False, index=df.index)
-        for offset in range(recovery_bars):
-            shifted_close = df['close'].shift(-offset)
-            recovery_check = recovery_check | (shifted_close > range_lower_quartile)
-        # Shift result back so detection fires on the confirmation bar
-        quick_recovery = recovery_check
-    else:
-        quick_recovery = df['close'] > range_lower_quartile
-
-    # Moderate volume (relaxed lower bound)
+    # Moderate volume (relaxed lower bound) — evaluated on the candidate bar
     moderate_volume = (df['volume_z'] > -0.5) & (df['volume_z'] < 2.0)
 
-    detected = shallow_break & quick_recovery & moderate_volume
+    # Candidate spring: shallow breakdown + moderate volume (no future data)
+    candidate = shallow_break & moderate_volume
 
-    # Confidence
-    range_mid = (rolling_high + rolling_low) / 2
+    # Confirmation-based recovery (same pattern as detect_spring_type_a /
+    # detect_upthrust): a candidate existed recovery_bars ago AND the current
+    # close is back above that candidate's lower quartile. Fires on the
+    # CONFIRMATION bar with zero lookahead — a recovery that did not HOLD
+    # through the confirmation bar does not fire.
+    if recovery_bars > 1:
+        detected = (
+            candidate.shift(recovery_bars).fillna(False).astype(bool) &
+            (df['close'] > range_lower_quartile.shift(recovery_bars))
+        )
+        conf_shift = recovery_bars
+    else:
+        detected = candidate & (df['close'] > range_lower_quartile)
+        conf_shift = 0
+
+    # Confidence: breakdown depth + volume from the CANDIDATE bar (shifted to
+    # the confirmation bar); recovery strength from the CURRENT close measured
+    # against the candidate's range.
+    quart_c = range_lower_quartile.shift(conf_shift)
+    high_c = rolling_high.shift(conf_shift)
     confidence = (
-        (breakdown_pct / breakdown_max).clip(0, 1) * 0.35 +
-        ((df['close'] - range_lower_quartile) / (rolling_high - range_lower_quartile + 1e-9)).clip(0, 1) * 0.35 +
-        (df['volume_z'].clip(-1, 3) / 4.0 + 0.25).clip(0, 1) * 0.30
+        (breakdown_pct.shift(conf_shift) / breakdown_max).clip(0, 1) * 0.35 +
+        ((df['close'] - quart_c) / (high_c - quart_c + 1e-9)).clip(0, 1) * 0.35 +
+        (df['volume_z'].shift(conf_shift).clip(-1, 3) / 4.0 + 0.25).clip(0, 1) * 0.30
     )
     confidence = confidence.fillna(0.0) * detected
 
@@ -1327,6 +1372,7 @@ def _apply_state_machine_validation(df: pd.DataFrame, cfg: dict) -> pd.DataFrame
     n = len(df)
     validated_arrays = {k: np.zeros(n, dtype=bool) for k in event_keys}
     phases = ['neutral'] * n
+    phase_dirs = ['neutral'] * n
     contexts = ['none'] * n
     confidence_mod_arrays = {k: np.ones(n, dtype=float) for k in event_keys}
 
@@ -1360,6 +1406,7 @@ def _apply_state_machine_validation(df: pd.DataFrame, cfg: dict) -> pd.DataFrame
             confidence_mod_arrays[k][i] = mod
 
         phases[i] = sm.get_phase()
+        phase_dirs[i] = sm.get_phase_dir()
         contexts[i] = sm.get_context_str()
 
     # Write back validated events and zero out confidence for invalidated events
@@ -1382,6 +1429,7 @@ def _apply_state_machine_validation(df: pd.DataFrame, cfg: dict) -> pd.DataFrame
 
     # Override phase with state-machine-derived phase
     df['wyckoff_phase_abc'] = phases
+    df['wyckoff_phase_dir'] = phase_dirs
     df['wyckoff_context'] = contexts
 
     sm_counts = {k: validated_arrays[k].sum() for k in event_keys}
@@ -1574,6 +1622,11 @@ def detect_all_wyckoff_events(df: pd.DataFrame, cfg: Optional[dict] = None,
         df = _apply_state_machine_validation(df, cfg)
         # Recompute sequence position based on SM-derived phases
         df['wyckoff_sequence_position'] = _compute_sequence_position(df)
+    else:
+        # Directional phase/context only exist via the state machine; keep the
+        # columns present (neutral) so consumers see a stable schema.
+        df['wyckoff_phase_dir'] = 'neutral'
+        df['wyckoff_context'] = 'none'
 
     # Apply higher-timeframe confidence modulation (on SM-validated events only)
     if htf_context is not None:

--- a/engine/wyckoff/events.py
+++ b/engine/wyckoff/events.py
@@ -261,7 +261,7 @@ class WyckoffStateMachine:
         # (higher low = the M2 signature; a low below SC_low is spring
         # territory, not an M2 LPS).
         if raw_events.get('lps', False) and self.context == WyckoffContext.ACCUMULATION:
-            if self.state in (WyckoffState.ACCUM_SOS, WyckoffState.ACCUM_LPS):
+            if self.state == WyckoffState.ACCUM_SOS:
                 validated['lps'] = True
                 self.state = WyckoffState.ACCUM_LPS
             elif (self.range_ref.ar_high > 0
@@ -350,7 +350,7 @@ class WyckoffStateMachine:
         # LPSY: after SOW (legacy) or M2 mirror — phase-C LPSY BEFORE any SOW,
         # lower high HOLDING BELOW resistance.
         if raw_events.get('lpsy', False) and self.context == WyckoffContext.DISTRIBUTION:
-            if self.state in (WyckoffState.DISTRIB_SOW, WyckoffState.DISTRIB_LPSY):
+            if self.state == WyckoffState.DISTRIB_SOW:
                 validated['lpsy'] = True
                 self.state = WyckoffState.DISTRIB_LPSY
             elif (self.range_ref.as_low > 0

--- a/engine/wyckoff/events.py
+++ b/engine/wyckoff/events.py
@@ -77,6 +77,7 @@ class WyckoffState(Enum):
     ACCUM_AR = "accum_ar"
     ACCUM_ST = "accum_st"
     ACCUM_SPRING = "accum_spring"
+    ACCUM_LPS_C = "accum_lps_c"   # M2 (Schematic #2): phase-C LPS BEFORE SOS
     ACCUM_SOS = "accum_sos"
     ACCUM_LPS = "accum_lps"
     # Distribution states
@@ -84,6 +85,7 @@ class WyckoffState(Enum):
     DISTRIB_AR = "distrib_ar"
     DISTRIB_ST = "distrib_st"
     DISTRIB_UT = "distrib_ut"
+    DISTRIB_LPSY_C = "distrib_lpsy_c"  # M2 mirror: phase-C LPSY BEFORE SOW
     DISTRIB_SOW = "distrib_sow"
     DISTRIB_LPSY = "distrib_lpsy"
 
@@ -242,18 +244,34 @@ class WyckoffStateMachine:
         if raw_events.get('sos', False):
             if self.context == WyckoffContext.ACCUMULATION:
                 if self.state in (WyckoffState.ACCUM_AR, WyckoffState.ACCUM_ST,
-                                 WyckoffState.ACCUM_SPRING):
+                                 WyckoffState.ACCUM_SPRING, WyckoffState.ACCUM_LPS_C):
                     validated['sos'] = True
                     self.state = WyckoffState.ACCUM_SOS
             elif self.context == WyckoffContext.NONE:
                 validated['sos'] = True
                 modifiers['sos'] = 0.5  # 50% confidence penalty for no-context SOS
 
-        # LPS: Requires prior SOS
+        # LPS: after SOS = BU/LPS (Schematic #1 & #2 phase D). M2 path
+        # (Schematic #2, default ON): a phase-C LPS BEFORE any SOS is valid
+        # when the range is established and the bar's low HOLDS ABOVE support
+        # (higher low = the M2 signature; a low below SC_low is spring
+        # territory, not an M2 LPS).
         if raw_events.get('lps', False) and self.context == WyckoffContext.ACCUMULATION:
-            if self.state == WyckoffState.ACCUM_SOS:
+            if self.state in (WyckoffState.ACCUM_SOS, WyckoffState.ACCUM_LPS):
                 validated['lps'] = True
                 self.state = WyckoffState.ACCUM_LPS
+            elif (self.cfg.get('sm_m2_path', True)
+                  and self.range_ref.ar_high > 0
+                  and self.state in (WyckoffState.ACCUM_ST,
+                                     WyckoffState.ACCUM_SPRING)
+                  and row['low'] > self.range_ref.sc_low):
+                # Schematic #2 structure constraints (NOT tuned numbers):
+                # phase-B work must precede the LPS (an ST or spring has
+                # occurred — never straight from AR), and ONE phase-C LPS per
+                # structure (no LPS_C self-loop; without this, every quiet dip
+                # in a range re-fires: 16 -> 2,727 events, a 170x explosion).
+                validated['lps'] = True
+                self.state = WyckoffState.ACCUM_LPS_C
 
         # --- DISTRIBUTION PATH ---
 
@@ -308,18 +326,29 @@ class WyckoffStateMachine:
         if raw_events.get('sow', False):
             if self.context == WyckoffContext.DISTRIBUTION:
                 if self.state in (WyckoffState.DISTRIB_AR, WyckoffState.DISTRIB_ST,
-                                 WyckoffState.DISTRIB_UT):
+                                 WyckoffState.DISTRIB_UT,
+                                 WyckoffState.DISTRIB_LPSY_C):
                     validated['sow'] = True
                     self.state = WyckoffState.DISTRIB_SOW
             elif self.context == WyckoffContext.NONE:
                 validated['sow'] = True
                 modifiers['sow'] = 0.5
 
-        # LPSY: Requires prior SOW
+        # LPSY: after SOW (legacy) or M2 mirror — phase-C LPSY BEFORE any SOW,
+        # lower high HOLDING BELOW resistance.
         if raw_events.get('lpsy', False) and self.context == WyckoffContext.DISTRIBUTION:
-            if self.state == WyckoffState.DISTRIB_SOW:
+            if self.state in (WyckoffState.DISTRIB_SOW, WyckoffState.DISTRIB_LPSY):
                 validated['lpsy'] = True
                 self.state = WyckoffState.DISTRIB_LPSY
+            elif (self.cfg.get('sm_m2_path', True)
+                  and self.range_ref.as_low > 0
+                  and self.state in (WyckoffState.DISTRIB_ST,
+                                     WyckoffState.DISTRIB_UT)
+                  and row['high'] < self.range_ref.bc_high):
+                # Mirror of the accumulation M2 constraints: phase-B work (ST
+                # or UT) must precede; one phase-C LPSY per structure.
+                validated['lpsy'] = True
+                self.state = WyckoffState.DISTRIB_LPSY_C
 
         return validated, modifiers
 
@@ -342,9 +371,11 @@ class WyckoffStateMachine:
             WyckoffState.NONE: 'neutral',
             WyckoffState.ACCUM_SC: 'A', WyckoffState.ACCUM_AR: 'A',
             WyckoffState.ACCUM_ST: 'A', WyckoffState.ACCUM_SPRING: 'C',
+            WyckoffState.ACCUM_LPS_C: 'C',
             WyckoffState.ACCUM_SOS: 'B', WyckoffState.ACCUM_LPS: 'D',
             WyckoffState.DISTRIB_BC: 'A', WyckoffState.DISTRIB_AR: 'A',
             WyckoffState.DISTRIB_ST: 'A', WyckoffState.DISTRIB_UT: 'C',
+            WyckoffState.DISTRIB_LPSY_C: 'C',
             WyckoffState.DISTRIB_SOW: 'B', WyckoffState.DISTRIB_LPSY: 'D',
         }
         return phase_map.get(self.state, 'neutral')

--- a/engine/wyckoff/events.py
+++ b/engine/wyckoff/events.py
@@ -260,7 +260,7 @@ class WyckoffStateMachine:
             if self.state in (WyckoffState.ACCUM_SOS, WyckoffState.ACCUM_LPS):
                 validated['lps'] = True
                 self.state = WyckoffState.ACCUM_LPS
-            elif (self.cfg.get('sm_m2_path', True)
+            elif (self.cfg.get('sm_m2_path', False)
                   and self.range_ref.ar_high > 0
                   and self.state in (WyckoffState.ACCUM_ST,
                                      WyckoffState.ACCUM_SPRING)
@@ -340,7 +340,7 @@ class WyckoffStateMachine:
             if self.state in (WyckoffState.DISTRIB_SOW, WyckoffState.DISTRIB_LPSY):
                 validated['lpsy'] = True
                 self.state = WyckoffState.DISTRIB_LPSY
-            elif (self.cfg.get('sm_m2_path', True)
+            elif (self.cfg.get('sm_m2_path', False)
                   and self.range_ref.as_low > 0
                   and self.state in (WyckoffState.DISTRIB_ST,
                                      WyckoffState.DISTRIB_UT)

--- a/engine/wyckoff/events.py
+++ b/engine/wyckoff/events.py
@@ -136,6 +136,8 @@ class WyckoffStateMachine:
         self.context = WyckoffContext.NONE
         self.range_ref = RangeReference()
         self.bars_in_structure = 0
+        # sm_m2_context_only shadow: phase-C reading without state/event change
+        self.m2_shadow_c = False
 
         # Config with sm_ prefix
         self.max_structure_bars = cfg.get('sm_max_structure_bars', 1000)
@@ -150,6 +152,7 @@ class WyckoffStateMachine:
         self.context = WyckoffContext.NONE
         self.range_ref = RangeReference()
         self.bars_in_structure = 0
+        self.m2_shadow_c = False
 
     def process_bar(self, bar_idx: int, row: dict, raw_events: dict) -> tuple:
         """
@@ -190,6 +193,7 @@ class WyckoffStateMachine:
                 sc_bar_idx=bar_idx,
             )
             self.bars_in_structure = 0
+            self.m2_shadow_c = False  # new structure: clear stale shadow phase
 
         # AR: Requires prior SC within lookback
         if raw_events.get('ar', False) and self.context == WyckoffContext.ACCUMULATION:
@@ -260,8 +264,7 @@ class WyckoffStateMachine:
             if self.state in (WyckoffState.ACCUM_SOS, WyckoffState.ACCUM_LPS):
                 validated['lps'] = True
                 self.state = WyckoffState.ACCUM_LPS
-            elif (self.cfg.get('sm_m2_path', False)
-                  and self.range_ref.ar_high > 0
+            elif (self.range_ref.ar_high > 0
                   and self.state in (WyckoffState.ACCUM_ST,
                                      WyckoffState.ACCUM_SPRING)
                   and row['low'] > self.range_ref.sc_low):
@@ -270,8 +273,17 @@ class WyckoffStateMachine:
                 # occurred — never straight from AR), and ONE phase-C LPS per
                 # structure (no LPS_C self-loop; without this, every quiet dip
                 # in a range re-fires: 16 -> 2,727 events, a 170x explosion).
-                validated['lps'] = True
-                self.state = WyckoffState.ACCUM_LPS_C
+                if self.cfg.get('sm_m2_path', False):
+                    validated['lps'] = True
+                    self.state = WyckoffState.ACCUM_LPS_C
+                elif self.cfg.get('sm_m2_context_only', False):
+                    # SHADOW phase-C: only wyckoff_phase_dir/_phase_abc
+                    # readings change — no event emission, no state change, so
+                    # event columns / scores / fusion inputs stay bit-identical
+                    # to the M2-off build. (Fusion reshuffle was the full
+                    # path's failure mode: train +13K / hold -5.2K. The phase
+                    # READING co-moved as an entry qualifier in both eras.)
+                    self.m2_shadow_c = True
 
         # --- DISTRIBUTION PATH ---
 
@@ -288,6 +300,7 @@ class WyckoffStateMachine:
                     bc_bar_idx=bar_idx,
                 )
                 self.bars_in_structure = 0
+                self.m2_shadow_c = False  # new structure: clear stale shadow
 
         # AS: Requires prior BC within lookback
         if raw_events.get('as', False) and self.context == WyckoffContext.DISTRIBUTION:
@@ -340,15 +353,17 @@ class WyckoffStateMachine:
             if self.state in (WyckoffState.DISTRIB_SOW, WyckoffState.DISTRIB_LPSY):
                 validated['lpsy'] = True
                 self.state = WyckoffState.DISTRIB_LPSY
-            elif (self.cfg.get('sm_m2_path', False)
-                  and self.range_ref.as_low > 0
+            elif (self.range_ref.as_low > 0
                   and self.state in (WyckoffState.DISTRIB_ST,
                                      WyckoffState.DISTRIB_UT)
                   and row['high'] < self.range_ref.bc_high):
                 # Mirror of the accumulation M2 constraints: phase-B work (ST
                 # or UT) must precede; one phase-C LPSY per structure.
-                validated['lpsy'] = True
-                self.state = WyckoffState.DISTRIB_LPSY_C
+                if self.cfg.get('sm_m2_path', False):
+                    validated['lpsy'] = True
+                    self.state = WyckoffState.DISTRIB_LPSY_C
+                elif self.cfg.get('sm_m2_context_only', False):
+                    self.m2_shadow_c = True  # shadow phase-C (see accum path)
 
         return validated, modifiers
 
@@ -367,6 +382,12 @@ class WyckoffStateMachine:
 
     def get_phase(self) -> str:
         """Return current Wyckoff phase letter based on state"""
+        # Context-only M2 shadow: report phase C while the underlying state is
+        # still the phase-B state (no state/event mutation — see M2 branches)
+        if self.m2_shadow_c and self.state in (
+                WyckoffState.ACCUM_ST, WyckoffState.ACCUM_SPRING,
+                WyckoffState.DISTRIB_ST, WyckoffState.DISTRIB_UT):
+            return 'C'
         phase_map = {
             WyckoffState.NONE: 'neutral',
             WyckoffState.ACCUM_SC: 'A', WyckoffState.ACCUM_AR: 'A',

--- a/scripts/rebuild/patch_v20_wyckoff.py
+++ b/scripts/rebuild/patch_v20_wyckoff.py
@@ -167,7 +167,14 @@ def main() -> None:
                     help="1-based worker index and total chunk count")
     ap.add_argument("--limit", type=int, help="smoke test: last N store bars")
     ap.add_argument("--stitch", action="store_true")
+    ap.add_argument("--version", default="V20_WYCKOFF",
+                    help="output store version tag (e.g. V21_M2); also names "
+                         "the chunk workdir so builds don't collide")
     args = ap.parse_args()
+
+    global OUT_DIR, V20
+    OUT_DIR = REPO / f"results/rebuild/{args.version.lower()}"
+    V20 = REPO / f"data/features_mtf/BTC_1H_FEATURES_{args.version}.parquet"
 
     ohlcv = load_ohlcv()
     if args.stitch:

--- a/scripts/rebuild/patch_v20_wyckoff.py
+++ b/scripts/rebuild/patch_v20_wyckoff.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""V20 wyckoff patch — recompute Wyckoff event columns with repaired code.
+
+Why: 2026-08-04 audit found (a) detect_spring_type_b read future closes in
+batch runs (look-ahead; fixed to the spring_a candidate/confirm pattern),
+(b) the state machine discarded nearly all springs/UTs because SC's
+triple-extreme gate almost never validates a structure (fixed with the
+sanctioned SOS/SOW-style no-context 0.5x-confidence fallback), and
+(c) wyckoff_phase_abc conflates accumulation/distribution direction (new
+directional columns: wyckoff_phase_dir, wyckoff_context).
+
+Replays bin/live/live_feature_computer._wyckoff_features() bar-by-bar over a
+bounded 1,000-bar buffer — the same path live uses — so store == live parity
+holds by construction. Only the wyckoff family is touched; V18's other
+columns are carried through unchanged.
+
+Usage:
+  python3 scripts/rebuild/patch_v20_wyckoff.py --chunk 1 6      # worker
+  python3 scripts/rebuild/patch_v20_wyckoff.py --limit 300      # smoke
+  python3 scripts/rebuild/patch_v20_wyckoff.py --stitch         # splice V20
+Chunks checkpoint every 2,000 bars and are resumable.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+STORE = REPO / "data/features_mtf/BTC_1H_FEATURES_V18_ROTATION.parquet"
+OUT_DIR = REPO / "results/rebuild/v20_wyckoff"
+V20 = REPO / "data/features_mtf/BTC_1H_FEATURES_V20_WYCKOFF.parquet"
+WARMUP = 1000
+CHECKPOINT_EVERY = 2000
+# String columns worth keeping in the store (all other object-dtype
+# diagnostics are dropped at stitch, as in the v15 patch)
+KEEP_STR_COLS = ["wyckoff_phase_abc", "wyckoff_phase_dir", "wyckoff_context"]
+
+logging.basicConfig(level=logging.WARNING)  # silence per-bar wyckoff INFO spam
+log = logging.getLogger("v20patch")
+log.setLevel(logging.INFO)
+
+
+def load_ohlcv() -> pd.DataFrame:
+    df = pd.read_parquet(STORE, columns=["open", "high", "low", "close", "volume"])
+    if df.index.tz is not None:
+        df.index = df.index.tz_localize(None)
+    return df.sort_index()
+
+
+def compute_rows(ohlcv: pd.DataFrame, start: int, end: int,
+                 out_path: Path) -> pd.DataFrame:
+    """Replay wyckoff features for ohlcv.iloc[start:end], resumable."""
+    from bin.live.live_feature_computer import LiveFeatureComputer
+
+    done = None
+    if out_path.exists():
+        done = pd.read_parquet(out_path)
+        n_done = len(done)
+        if n_done >= end - start:
+            log.info("%s already complete (%d rows)", out_path.name, n_done)
+            return done
+        start = start + n_done
+        log.info("resuming %s at offset %d", out_path.name, n_done)
+
+    lfc = LiveFeatureComputer(buffer_size=WARMUP)
+    warm_lo = max(0, start - WARMUP)
+    if start > warm_lo:  # chunk 1 starts at row 0: no warmup exists (cold start)
+        lfc.ingest_candles(ohlcv.iloc[warm_lo:start])
+
+    rows, t0 = [], time.time()
+    idx = ohlcv.index
+    for i in range(start, end):
+        ts = idx[i]
+        bar = ohlcv.iloc[i]
+        new_row = pd.DataFrame([{c: float(bar[c]) for c in
+                                 ("open", "high", "low", "close", "volume")}],
+                               index=[ts])
+        lfc._buf = new_row.copy() if lfc._buf is None else pd.concat([lfc._buf, new_row])
+        if len(lfc._buf) > lfc.buffer_size:
+            lfc._buf = lfc._buf.iloc[-lfc.buffer_size:]
+
+        feats: dict = {"__ts": ts}
+        feats.update(lfc._wyckoff_features())
+        rows.append(feats)
+
+        n = i - start + 1
+        if n % CHECKPOINT_EVERY == 0 or i == end - 1:
+            chunk = pd.DataFrame(rows).set_index("__ts")
+            merged = pd.concat([done, chunk]) if done is not None else chunk
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            merged.to_parquet(out_path)
+            done, rows = merged, []
+            rate = n / (time.time() - t0)
+            eta_h = (end - 1 - i) / rate / 3600 if rate > 0 else float("inf")
+            log.info("%s: %d/%d bars (%.1f bars/s, eta %.1fh)",
+                     out_path.name, n, end - start, rate, eta_h)
+    return done
+
+
+def stitch(ohlcv_index: pd.Index) -> None:
+    chunks = sorted(OUT_DIR.glob("chunk_*.parquet"))
+    if not chunks:
+        sys.exit("no chunks found")
+    patch = pd.concat([pd.read_parquet(c) for c in chunks])
+    patch = patch[~patch.index.duplicated(keep="last")].sort_index()
+    # drop non-numeric diagnostics EXCEPT the directional phase/context strings
+    drop = [c for c in patch.columns
+            if patch[c].dtype == object and c not in KEEP_STR_COLS]
+    patch = patch.drop(columns=drop, errors="ignore")
+    missing = ohlcv_index.difference(patch.index)
+    if len(missing):
+        sys.exit(f"patch incomplete: {len(missing)} store rows missing "
+                 f"(first: {missing[0]})")
+    patch = patch.reindex(ohlcv_index)
+
+    store = pd.read_parquet(STORE)
+    if store.index.tz is not None:
+        store.index = store.index.tz_localize(None)
+    replaced = [c for c in patch.columns if c in store.columns]
+    added = [c for c in patch.columns if c not in store.columns]
+    for c in patch.columns:
+        store[c] = patch[c].values
+    store.to_parquet(V20)
+    print(f"V20 written: {V20}")
+    print(f"  rows {len(store)}, replaced {len(replaced)} cols, added {len(added)} cols")
+    print(f"  added: {sorted(added)}")
+    key = ["wyckoff_spring_a", "wyckoff_spring_b", "wyckoff_ut", "wyckoff_utad",
+           "wyckoff_sc", "wyckoff_bullish_score", "wyckoff_bearish_score"]
+    print("  event counts / nonzero rates (patched):")
+    for c in key:
+        if c in store.columns:
+            s = store[c].fillna(0)
+            print(f"    {c:26s} nonzero={int((s != 0).sum()):6d} "
+                  f"({float((s != 0).mean()):6.2%})")
+    if "wyckoff_phase_dir" in store.columns:
+        print("  phase_dir distribution:")
+        print(store["wyckoff_phase_dir"].value_counts().to_string())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chunk", nargs=2, type=int, metavar=("I", "N"),
+                    help="1-based worker index and total chunk count")
+    ap.add_argument("--limit", type=int, help="smoke test: last N store bars")
+    ap.add_argument("--stitch", action="store_true")
+    args = ap.parse_args()
+
+    ohlcv = load_ohlcv()
+    if args.stitch:
+        stitch(ohlcv.index)
+        return
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    n = len(ohlcv)
+    if args.limit:
+        out = OUT_DIR / "smoke.parquet"
+        out.unlink(missing_ok=True)
+        df = compute_rows(ohlcv, n - args.limit, n, out)
+        for c in ["wyckoff_spring_a", "wyckoff_spring_b", "wyckoff_ut",
+                  "wyckoff_bullish_score", "tf1d_wyckoff_bullish_score"]:
+            if c in df.columns:
+                s = df[c].fillna(0)
+                print(f"{c:28s} nonzero={float((s != 0).mean()):6.2%}  "
+                      f"max={float(s.max()):.3f}")
+        print(f"columns produced: {len(df.columns)}")
+        return
+    if not args.chunk:
+        sys.exit("need --chunk I N, --limit, or --stitch")
+    i, total = args.chunk
+    per = (n + total - 1) // total
+    start, end = (i - 1) * per, min(i * per, n)
+    log.info("chunk %d/%d: rows %d..%d (%s -> %s)", i, total, start, end - 1,
+             ohlcv.index[start], ohlcv.index[end - 1])
+    compute_rows(ohlcv, start, end, OUT_DIR / f"chunk_{i:02d}.parquet")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rebuild/patch_v20_wyckoff.py
+++ b/scripts/rebuild/patch_v20_wyckoff.py
@@ -110,9 +110,26 @@ def stitch(ohlcv_index: pd.Index) -> None:
         sys.exit("no chunks found")
     patch = pd.concat([pd.read_parquet(c) for c in chunks])
     patch = patch[~patch.index.duplicated(keep="last")].sort_index()
-    # drop non-numeric diagnostics EXCEPT the directional phase/context strings
+    # Event booleans come back as object dtype (bool + None on cold-start rows).
+    # The v15 patch dropped ALL object columns, which silently discarded the
+    # event bools and left the store carrying V14-era values — coerce them to
+    # float 0/1 instead. Keep the directional strings; drop other diagnostics.
+    for c in patch.columns:
+        if patch[c].dtype == object and c not in KEEP_STR_COLS:
+            coerced = pd.to_numeric(
+                patch[c].map(lambda v: float(v) if isinstance(v, (bool, int, float))
+                             and v == v else 0.0),
+                errors="coerce").fillna(0.0)
+            n_true = int((coerced != 0).sum())
+            sample = patch[c].dropna()
+            if len(sample) and all(isinstance(v, (bool, int, float))
+                                   for v in sample.head(200)):
+                patch[c] = coerced
+                log.info("coerced object col %s to float (%d nonzero)", c, n_true)
     drop = [c for c in patch.columns
             if patch[c].dtype == object and c not in KEEP_STR_COLS]
+    if drop:
+        log.info("dropping non-numeric diagnostics: %s", drop)
     patch = patch.drop(columns=drop, errors="ignore")
     missing = ohlcv_index.difference(patch.index)
     if len(missing):

--- a/tests/test_seller_flow_boost.py
+++ b/tests/test_seller_flow_boost.py
@@ -75,3 +75,14 @@ def test_exodus_refusal_parity():
     assert "stables_rot_rising" in LF
     cfg = json.loads((REPO / "configs/champion_paper.json").read_text())
     assert cfg["structural_checks"]["gate_params"]["wt_no_exodus_K"] == 1
+
+
+def test_wyckoff_phase_boost_parity():
+    """Boost 6 (2026-08-04): C_accum long context boost, capex-scoped, present
+    in both engines; live metadata enrichment carries wyckoff_phase_dir.
+    (Config enablement is asserted separately once the deploy decision lands.)"""
+    for src in (BT, LV):
+        assert "wyckoff_phase_boost" in src
+        assert "wyckoff_phase_C_accum" in src
+    enrich = LV[LV.index("Step 3e"):LV.index("Step 4:")]
+    assert "wyckoff_phase_dir" in enrich

--- a/tests/test_wyckoff_causality.py
+++ b/tests/test_wyckoff_causality.py
@@ -1,0 +1,128 @@
+"""Wyckoff event detection must be causal: batch results over full history must
+match what a live walk (which only ever sees past bars) would have produced.
+
+Guards the bug class found 2026-08-04: detect_spring_type_b read future closes
+(`close.shift(-offset)`) with a "shift back" comment whose shift was never applied,
+so wyckoff_spring_b repainted in batch runs while live (no future bars) could not
+reproduce it.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from engine.wyckoff.events import detect_all_wyckoff_events, detect_spring_type_b
+
+EVENT_COLS = [
+    'wyckoff_sc', 'wyckoff_bc', 'wyckoff_ar', 'wyckoff_as', 'wyckoff_st',
+    'wyckoff_sos', 'wyckoff_sow', 'wyckoff_spring_a', 'wyckoff_spring_b',
+    'wyckoff_ut', 'wyckoff_utad', 'wyckoff_lps', 'wyckoff_lpsy',
+]
+
+
+def _range_df(n=160, base=100.0, half_width=2.0, volume=1000.0):
+    """Sideways range: lows ~base-2, highs ~base+2, flat volume (volume_z ~ 0)."""
+    idx = pd.date_range('2024-01-01', periods=n, freq='1h')
+    rng = np.random.default_rng(42)
+    close = base + rng.normal(0, 0.3, n)
+    high = close + half_width * 0.5 + rng.uniform(0, 0.3, n)
+    low = close - half_width * 0.5 - rng.uniform(0, 0.3, n)
+    low = np.clip(low, base - half_width, None)
+    high = np.clip(high, None, base + half_width)
+    vol = volume + rng.uniform(-50, 50, n)
+    return pd.DataFrame(
+        {'open': close, 'high': high, 'low': low, 'close': close, 'volume': vol},
+        index=idx,
+    )
+
+
+def _inject_shallow_spring(df, at, breakdown=0.008, recover_close=100.5):
+    """Shallow breakdown below the rolling low at bar `at`, recovery on later bars.
+
+    The candidate bar closes BELOW the range's lower quartile (no same-bar
+    recovery) so only the following bars provide the recovery — exactly the
+    shape that exposes a future-read in the recovery check.
+    """
+    rolling_low = df['low'].rolling(20).min().shift(1)
+    ref_low = float(rolling_low.iloc[at])
+    df.iloc[at, df.columns.get_loc('low')] = ref_low * (1 - breakdown)
+    df.iloc[at, df.columns.get_loc('close')] = ref_low * 1.003  # below lower quartile
+    df.iloc[at, df.columns.get_loc('open')] = ref_low * 1.01
+    for k in range(1, 4):
+        df.iloc[at + k, df.columns.get_loc('close')] = recover_close
+        df.iloc[at + k, df.columns.get_loc('low')] = recover_close - 0.5
+        df.iloc[at + k, df.columns.get_loc('high')] = recover_close + 0.5
+    return df
+
+
+def _fixture():
+    df = _range_df()
+    df = _inject_shallow_spring(df, at=60)
+    df = _inject_shallow_spring(df, at=110)
+    return df
+
+
+@pytest.mark.parametrize('sm_enabled', [False, True],
+                         ids=['raw-detectors', 'with-state-machine'])
+def test_batch_matches_truncated_walk(sm_enabled):
+    """For sampled bars t, detect_all on df[:t+1] must agree at bar t with
+    detect_all on the full df — i.e., no detector may use future bars."""
+    df = _fixture()
+    cfg = {'state_machine_enabled': sm_enabled}
+
+    full = detect_all_wyckoff_events(df.copy(), cfg=dict(cfg))
+
+    # Sample every bar around the injected episodes plus a tail scatter
+    sample_ts = list(range(58, 70)) + list(range(108, 120)) + [140, 150, 159]
+    for t in sample_ts:
+        trunc = detect_all_wyckoff_events(df.iloc[:t + 1].copy(), cfg=dict(cfg))
+        for col in EVENT_COLS + ['wyckoff_phase_abc']:
+            if col not in full.columns:
+                continue
+            full_val = full[col].iloc[t]
+            trunc_val = trunc[col].iloc[-1]
+            assert (full_val == trunc_val) or (
+                pd.isna(full_val) and pd.isna(trunc_val)
+            ), (
+                f"{col} not causal at bar {t} (sm={sm_enabled}): "
+                f"batch={full_val!r} vs truncated-walk={trunc_val!r}"
+            )
+
+
+def test_spring_b_fires_on_confirmation_bar_not_breakdown_bar():
+    """detect_spring_type_b must fire on the confirmation bar (breakdown +
+    recovery_bars), never on the breakdown bar itself (that would require
+    knowing future closes)."""
+    df = _fixture()
+    detected, confidence = detect_spring_type_b(df.copy(), cfg={})
+
+    fired = list(np.flatnonzero(detected.values))
+    assert fired, "fixture should produce at least one spring_b detection"
+
+    breakdown_bars = {60, 110}
+    for b in breakdown_bars:
+        assert not detected.iloc[b], (
+            f"spring_b fired on the breakdown bar {b} — only possible by "
+            f"reading future closes (look-ahead)"
+        )
+
+    recovery_bars = 3  # default
+    expected = {b + recovery_bars for b in breakdown_bars}
+    assert expected.issubset(set(fired)), (
+        f"expected confirmation-bar firings at {sorted(expected)}, got {fired}"
+    )
+    # Confidence must sit on the firing bars only
+    assert (confidence[detected].fillna(0) > 0).all()
+    assert float(confidence[~detected].abs().max()) == 0.0
+
+
+def test_spring_b_truncation_direct():
+    """Function-level causality: truncating the frame at the breakdown bar must
+    not change whether that bar is (not) a detection."""
+    df = _fixture()
+    full_det, _ = detect_spring_type_b(df.copy(), cfg={})
+    for t in [60, 61, 62, 63, 110, 111, 112, 113]:
+        trunc_det, _ = detect_spring_type_b(df.iloc[:t + 1].copy(), cfg={})
+        assert bool(full_det.iloc[t]) == bool(trunc_det.iloc[-1]), (
+            f"spring_b repaints at bar {t}: batch={bool(full_det.iloc[t])} "
+            f"vs walk={bool(trunc_det.iloc[-1])}"
+        )

--- a/tests/test_wyckoff_m2_sequence.py
+++ b/tests/test_wyckoff_m2_sequence.py
@@ -29,7 +29,7 @@ def _drive_phase_ab(sm):
 
 def test_m2_full_sequence_lps_before_sos():
     """SC->AR->ST -> quiet undercut (ST-B) -> phase-C LPS -> SOS -> BU/LPS."""
-    sm = WyckoffStateMachine({})
+    sm = WyckoffStateMachine({'sm_m2_path': True})
     _drive_phase_ab(sm)
 
     # ST in Phase B: quiet undercut of SC low must NOT invalidate the structure
@@ -59,7 +59,7 @@ def test_m2_full_sequence_lps_before_sos():
 def test_m2_lps_below_support_rejected():
     """An 'LPS' whose low breaks the SC low is NOT a phase-C LPS (that would be
     spring territory) — the M2 path must reject it."""
-    sm = WyckoffStateMachine({})
+    sm = WyckoffStateMachine({'sm_m2_path': True})
     _drive_phase_ab(sm)
     v, _ = sm.process_bar(14, _row(low=99.5, close=104.0), {'lps': True})
     assert not v['lps'], "low below SC support is not an M2 phase-C LPS"
@@ -67,7 +67,7 @@ def test_m2_lps_below_support_rejected():
 
 def test_m2_path_config_gated_off():
     """sm_m2_path=False reproduces legacy behavior (LPS only after SOS)."""
-    sm = WyckoffStateMachine({'sm_m2_path': False})
+    sm = WyckoffStateMachine({})  # default = OFF (evidence-gated 2026-08-04)
     _drive_phase_ab(sm)
     v, _ = sm.process_bar(14, _row(low=103.0, close=105.0), {'lps': True})
     assert not v['lps'], "legacy mode: pre-SOS LPS must stay rejected"
@@ -77,7 +77,7 @@ def test_m2_path_config_gated_off():
 def test_m2_distribution_mirror_lpsy_before_sow():
     """Mirror: BC->AS->UT context, LPSY (lower high BELOW resistance) before SOW.
     Phase-B work (a UT) must precede the LPSY — never straight from AS/AR."""
-    sm = WyckoffStateMachine({})
+    sm = WyckoffStateMachine({'sm_m2_path': True})
     v, _ = sm.process_bar(0, _row(low=98, close=99.5, high=110, volume_z=3.0),
                           {'bc': True})
     assert v['bc'] and sm.state == WyckoffState.DISTRIB_BC

--- a/tests/test_wyckoff_m2_sequence.py
+++ b/tests/test_wyckoff_m2_sequence.py
@@ -104,3 +104,20 @@ def test_m2_distribution_mirror_lpsy_before_sow():
     v, _ = sm.process_bar(12, _row(low=95, close=96, high=99, volume_z=2.0),
                           {'sow': True})
     assert v['sow'], "SOW must be reachable from the phase-C LPSY state"
+
+
+def test_m2_context_only_shadow():
+    """sm_m2_context_only: phase reads 'C' but NO event emission and NO state
+    change — event columns/scores stay bit-identical to M2-off."""
+    sm = WyckoffStateMachine({'sm_m2_context_only': True})
+    _drive_phase_ab(sm)
+    v, _ = sm.process_bar(14, _row(low=103.0, close=105.0), {'lps': True})
+    assert not v['lps'], "context-only must NOT emit the lps event"
+    assert sm.state == WyckoffState.ACCUM_ST, "context-only must NOT change state"
+    assert sm.get_phase() == 'C'
+    assert sm.get_phase_dir() == 'C_accum'
+    # SOS still validates from the real (unchanged) ST state, ending the shadow
+    v, _ = sm.process_bar(18, _row(low=108, close=112, high=113, volume_z=2.0),
+                          {'sos': True})
+    assert v['sos'] and sm.state == WyckoffState.ACCUM_SOS
+    assert sm.get_phase() != 'C', "shadow must not apply after the state advances"

--- a/tests/test_wyckoff_m2_sequence.py
+++ b/tests/test_wyckoff_m2_sequence.py
@@ -1,0 +1,106 @@
+"""Wyckoff Accumulation Schematic #2 (M2) sequencer path.
+
+M2 = accumulation WITHOUT a spring (Bogomazov/Pruden Schematic #2, and the
+pattern Wyckoff_Insider trades most): PS -> SC -> AR -> ST -> [ST in Phase B,
+undercut allowed] -> LPS in Phase C (higher low ABOVE support) -> SOS ->
+BU/LPS -> markup. The pre-M2 sequencer only accepted an LPS *after* an SOS,
+making the M2 signature moment unrepresentable.
+"""
+import pytest
+
+from engine.wyckoff.events import WyckoffStateMachine, WyckoffState, WyckoffContext
+
+
+def _row(low, close, high=None, volume_z=0.0):
+    high = high if high is not None else close + 1
+    return {'open': close, 'high': high, 'low': low, 'close': close,
+            'volume_z': volume_z}
+
+
+def _drive_phase_ab(sm):
+    """SC -> AR -> ST: establish the accumulation range (sc_low=100, ar_high=110)."""
+    v, _ = sm.process_bar(0, _row(low=100, close=102, volume_z=3.0), {'sc': True})
+    assert v['sc'] and sm.state == WyckoffState.ACCUM_SC
+    v, _ = sm.process_bar(3, _row(low=105, close=109, high=110), {'ar': True})
+    assert v['ar'] and sm.state == WyckoffState.ACCUM_AR
+    v, _ = sm.process_bar(6, _row(low=101, close=103, volume_z=0.5), {'st': True})
+    assert v['st'] and sm.state == WyckoffState.ACCUM_ST
+
+
+def test_m2_full_sequence_lps_before_sos():
+    """SC->AR->ST -> quiet undercut (ST-B) -> phase-C LPS -> SOS -> BU/LPS."""
+    sm = WyckoffStateMachine({})
+    _drive_phase_ab(sm)
+
+    # ST in Phase B: quiet undercut of SC low must NOT invalidate the structure
+    sm.process_bar(10, _row(low=99.0, close=101.5, volume_z=-0.5), {})
+    assert sm.context == WyckoffContext.ACCUMULATION, \
+        "quiet undercut (low < SC low, weak volume) must not reset the structure"
+
+    # Phase C LPS: higher low holding ABOVE support, BEFORE any SOS
+    v, mods = sm.process_bar(14, _row(low=103.0, close=105.0, volume_z=-0.3),
+                             {'lps': True})
+    assert v['lps'], "M2 path: LPS before SOS must validate (higher low above support)"
+    assert sm.state == WyckoffState.ACCUM_LPS_C
+    assert sm.get_phase() == 'C'
+    assert sm.get_phase_dir() == 'C_accum'
+
+    # SOS reachable FROM the phase-C LPS
+    v, _ = sm.process_bar(18, _row(low=108, close=112, high=113, volume_z=2.0),
+                          {'sos': True})
+    assert v['sos'], "SOS must be reachable from the phase-C LPS state"
+    assert sm.state == WyckoffState.ACCUM_SOS
+
+    # BU/LPS: post-SOS LPS still works (legacy path)
+    v, _ = sm.process_bar(20, _row(low=109, close=111, volume_z=-0.2), {'lps': True})
+    assert v['lps'] and sm.state == WyckoffState.ACCUM_LPS
+
+
+def test_m2_lps_below_support_rejected():
+    """An 'LPS' whose low breaks the SC low is NOT a phase-C LPS (that would be
+    spring territory) — the M2 path must reject it."""
+    sm = WyckoffStateMachine({})
+    _drive_phase_ab(sm)
+    v, _ = sm.process_bar(14, _row(low=99.5, close=104.0), {'lps': True})
+    assert not v['lps'], "low below SC support is not an M2 phase-C LPS"
+
+
+def test_m2_path_config_gated_off():
+    """sm_m2_path=False reproduces legacy behavior (LPS only after SOS)."""
+    sm = WyckoffStateMachine({'sm_m2_path': False})
+    _drive_phase_ab(sm)
+    v, _ = sm.process_bar(14, _row(low=103.0, close=105.0), {'lps': True})
+    assert not v['lps'], "legacy mode: pre-SOS LPS must stay rejected"
+    assert sm.state == WyckoffState.ACCUM_ST
+
+
+def test_m2_distribution_mirror_lpsy_before_sow():
+    """Mirror: BC->AS->UT context, LPSY (lower high BELOW resistance) before SOW.
+    Phase-B work (a UT) must precede the LPSY — never straight from AS/AR."""
+    sm = WyckoffStateMachine({})
+    v, _ = sm.process_bar(0, _row(low=98, close=99.5, high=110, volume_z=3.0),
+                          {'bc': True})
+    assert v['bc'] and sm.state == WyckoffState.DISTRIB_BC
+    v, _ = sm.process_bar(3, _row(low=100, close=101, high=104), {'as': True})
+    assert v['as'] and sm.state == WyckoffState.DISTRIB_AR
+
+    # Straight from AR, an LPSY must be REJECTED (no phase-B work yet)
+    v, _ = sm.process_bar(5, _row(low=102, close=104, high=107), {'lpsy': True})
+    assert not v['lpsy'], "LPSY straight from AR must be rejected (needs UT/ST first)"
+
+    # Phase-B work: UT (fake poke near resistance)
+    v, _ = sm.process_bar(6, _row(low=105, close=107, high=109.5, volume_z=0.8),
+                          {'ut': True})
+    assert v['ut'] and sm.state == WyckoffState.DISTRIB_UT
+
+    # Phase C LPSY: lower high holding BELOW resistance, before any SOW
+    v, _ = sm.process_bar(8, _row(low=102, close=104, high=107, volume_z=-0.3),
+                          {'lpsy': True})
+    assert v['lpsy'], "M2 mirror: LPSY before SOW must validate"
+    assert sm.state == WyckoffState.DISTRIB_LPSY_C
+    assert sm.get_phase() == 'C'
+    assert sm.get_phase_dir() == 'C_distrib'
+
+    v, _ = sm.process_bar(12, _row(low=95, close=96, high=99, volume_z=2.0),
+                          {'sow': True})
+    assert v['sow'], "SOW must be reachable from the phase-C LPSY state"


### PR DESCRIPTION
## Summary
- **Look-ahead bug fixed**: `detect_spring_type_b` read future closes (`shift(-offset)`) with a "shift back" comment whose shift was never written — batch runs repainted while live could not reproduce. Rewritten to the causal candidate/confirm pattern already used by spring_a/UT (fires on the confirmation bar). Guarded by new `tests/test_wyckoff_causality.py` (batch-vs-truncated-walk agreement for ALL event columns — fails on the old code exactly at `wyckoff_spring_b`).
- **Spring/UT detection unstarved**: the state machine discarded any spring/UT lacking a validated SC→AR structure, and SC's triple-extreme gate almost never validates one (9 springs in 8.5 years). Extended the sanctioned SOS/SOW no-context fallback (0.5x confidence, `sm_no_context_fallback` default ON) to spring_a/spring_b/UT/UTAD. Counts: spring_a 9→77, spring_b 54→169 (now causal), ut/utad 6→19; all other detectors bit-unchanged.
- **Directional phase**: new `wyckoff_phase_dir` ('C_accum'/'C_distrib') + exported `wyckoff_context` — the bare phase letter conflates accumulation and distribution (both ACCUM_SPRING and DISTRIB_UT map to 'C').
- **V20 store**: `scripts/rebuild/patch_v20_wyckoff.py` (live-replay additive patch, V18→V20, store==live parity by construction). Also fixes the v15-era stitch defect that silently dropped object-dtype event booleans (V15/V18's event bools were V14-era values all along).

## Validation
- `tests/test_wyckoff_causality.py` 4/4 + standard suites (23 tests green)
- V20 store validator: 8 PASS / 0 FAIL
- **Champion co-move (champion_paper.json, position-level)**:
  - TRAIN 2018-22: PF 1.193→1.192, $98,535→$97,566 (−1.0%, within noise)
  - HOLDOUT 2025-26: PF 1.028→**1.114**, $2,867→**$12,159** (+$9.3K)
- Honesty notes: consensus-14 label recall unchanged 0/14 (curated events are daily-scale; harness granularity mismatch documented); holdout gain decomposes as bleeders bleeding less (liquidity_sweep +$4.9K, TWT +$4.1K, LC +$2.7K) with wick_trap −$5.0K reshuffle — watch wick_trap live share post-deploy.

NOT deployed — live rollout is a separate explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directional Wyckoff phase and context information.
  * Added phase-C LPS/LPSY detection and optional sequence validation.
  * Improved profit-target scaling for qualifying long-position price levels with legacy fallback.
  * Added fallback detection for Spring, Upthrust, and UTAD events without structural context.
  * Added optional phase-based position sizing boosts and configurable cooldown behavior.

* **Bug Fixes**
  * Corrected Spring Type B timing and confirmation-bar confidence reporting.
  * Improved lower-wick rejection analysis.

* **Tests & Documentation**
  * Expanded causality and sequence coverage.
  * Documented validation, rebuilds, recall gaps, and backtest results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->