### PR TITLE
feat: Boost 7 rotation-calm live + non-binding paper wallet

### DIFF
--- a/bin/backtest_v11_standalone.py
+++ b/bin/backtest_v11_standalone.py
@@ -1173,6 +1173,25 @@ class StandaloneBacktestEngine:
                             sig_meta['sizing_boosts']['reasons'].append(
                                 'wyckoff_phase_C_accum (1.25x capex)')
 
+                    # Boost 7 (validated 2026-08-06 on non-binding wallet):
+                    # Rotation-calm book-wide. stables_rot_rising == 0 = money NOT
+                    # fleeing to stables (calm); == 1 = defensive rotation (dips are
+                    # exodus stairs, not accumulation). Unconstrained battery: ΔPnL
+                    # +$34.4K/+$29.5K/+$8.1K, ΔPF + in all three windows; cohort PF
+                    # 1.46/1.94/1.52 beats book 1.19/1.37/1.11 (addendum 22).
+                    # Deployed alongside the 20x wallet so expression never
+                    # self-cannibalizes. NaN/missing => NO boost.
+                    if (self.config.get('rotation_calm_boost') or {}).get('enabled') \
+                       and intent.signal.direction == 'long':
+                        rot = row.get('stables_rot_rising', None)
+                        if rot is not None and rot == rot and float(rot) == 0.0:
+                            intent.allocated_size_pct *= 1.25
+                            sig_meta['sizing_boosts']['multiplier'] *= 1.25
+                            sig_meta['sizing_boosts']['capex_mult'] = \
+                                sig_meta['sizing_boosts'].get('capex_mult', 1.0) * 1.25
+                            sig_meta['sizing_boosts']['reasons'].append(
+                                'rotation_calm stables_rot_rising=0 (1.25x capex)')
+
                 # Step 5: Execute allocations
                 for intent in intents:
                     sig = intent.signal
@@ -2343,6 +2362,14 @@ def main():
         config = json.load(f)
 
     logger.info(f"Loaded config: {config.get('version', 'unknown')}")
+
+    # Config-driven wallet (2026-08-06): configs whose position_sizing pcts are
+    # calibrated to a specific capital base carry `initial_cash`; honor it unless
+    # the CLI explicitly overrides (i.e. CLI still at its default).
+    cfg_cash = config.get('initial_cash')
+    if cfg_cash and args.initial_cash == 100_000.0:
+        args.initial_cash = float(cfg_cash)
+        logger.info(f"initial_cash from config: ${args.initial_cash:,.0f}")
 
     # Validate feature store exists
     feature_store_path = Path(args.feature_store)

--- a/bin/live/coinbase_runner.py
+++ b/bin/live/coinbase_runner.py
@@ -147,6 +147,17 @@ class CoinbasePaperRunner:
         verbose: bool = False,
     ):
         self.config_path = config_path
+        # Config-driven wallet (2026-08-06): position_sizing pcts are calibrated
+        # to the config's capital base — honor config initial_cash unless the
+        # CLI explicitly overrides (CLI still at its default).
+        try:
+            with open(config_path) as _cf:
+                _cfg_cash = json.load(_cf).get('initial_cash')
+            if _cfg_cash and initial_cash == DEFAULT_INITIAL_CASH:
+                initial_cash = float(_cfg_cash)
+                logger.info("initial_cash from config: $%s", f"{initial_cash:,.0f}")
+        except Exception as _e:
+            logger.warning("could not read initial_cash from config: %s", _e)
         self.initial_cash = initial_cash
         self.commission_rate = commission_rate
         self.slippage_bps = slippage_bps

--- a/bin/live/v11_shadow_runner.py
+++ b/bin/live/v11_shadow_runner.py
@@ -1337,6 +1337,10 @@ class V11ShadowRunner:
             pdir = features.get('wyckoff_phase_dir', None)
             if isinstance(pdir, str) and pdir:
                 s.metadata['wyckoff_phase_dir'] = pdir
+            # Stables rotation for Boost 7 (validated 2026-08-06)
+            rot = features.get('stables_rot_rising', None)
+            if rot is not None and rot == rot:
+                s.metadata['stables_rot_rising'] = float(rot)
 
         # Step 4: Portfolio allocation (bypass duplicate check in data-collection mode)
         if self.bypass_threshold:
@@ -1451,6 +1455,22 @@ class V11ShadowRunner:
                         'wyckoff_phase_C_accum (1.25x capex)')
                     logger.info(f"[WYCKOFF_PHASE_BOOST] {intent.signal.archetype_id} "
                                 f"C_accum → 1.25x capex sizing ({intent.allocated_size_pct:.3f})")
+
+            # Boost 7: rotation-calm (validated 2026-08-06 on non-binding wallet:
+            # ΔPnL +$34.4K/+$29.5K/+$8.1K, cohort PF beats book in all three eras).
+            # Money NOT fleeing to stables → any long sized up. NaN => no boost.
+            if ((self.config.get('rotation_calm_boost') or {}).get('enabled')
+                    and intent.signal.direction == 'long'):
+                rot = sig_meta.get('stables_rot_rising', None)
+                if rot is not None and rot == rot and float(rot) == 0.0:
+                    intent.allocated_size_pct *= 1.25
+                    sig_meta['sizing_boosts']['multiplier'] *= 1.25
+                    sig_meta['sizing_boosts']['capex_mult'] = \
+                        sig_meta['sizing_boosts'].get('capex_mult', 1.0) * 1.25
+                    sig_meta['sizing_boosts']['reasons'].append(
+                        'rotation_calm stables_rot_rising=0 (1.25x capex)')
+                    logger.info(f"[ROTATION_CALM_BOOST] {intent.signal.archetype_id} "
+                                f"rot=0 → 1.25x capex sizing ({intent.allocated_size_pct:.3f})")
 
         # Update signal tracking for portfolio rejections
         for rej in rejections:

--- a/configs/champion_paper.json
+++ b/configs/champion_paper.json
@@ -205,10 +205,12 @@
       "Probabilistic mode for smooth regime transitions"
     ]
   },
+  "initial_cash": 2000000,
+  "_initial_cash_note": "2026-08-06 user directive: the paper wallet is measurement infrastructure, not a realism constraint — sized 20x so funding never binds (the $100K wallet was silently rejecting real edges via margin crowd-out). position_sizing pcts scaled /20 so per-trade DOLLARS are unchanged ($2,000 risk, $35K margin cap, $52.5K notional at 1.5x). Backtester and live runner both read initial_cash from this config.",
   "position_sizing": {
-    "risk_per_trade_pct": 0.02,
-    "max_margin_per_position_pct": 0.35,
-    "max_position_size_pct": 0.15,
+    "risk_per_trade_pct": 0.001,
+    "max_margin_per_position_pct": 0.0175,
+    "max_position_size_pct": 0.0075,
     "use_atr_scaling": true,
     "dynamic_sizing_enabled": true,
     "fusion_size_tiers": [
@@ -297,5 +299,9 @@
   "wyckoff_phase_boost": {
     "enabled": true,
     "_note": "Boost 6 (2026-08-04): C_accum long context 1.25x capex \u2014 validated co-move (train +$8.6K DD better, hold +$769); shadow phase, zero fusion leakage"
+  },
+  "rotation_calm_boost": {
+    "enabled": true,
+    "_note": "Boost 7 (2026-08-06): rotation-calm long 1.25x \u2014 validated 3/3 on non-binding wallet (\u0394PnL +$34.4K/+$29.5K/+$8.1K; cohort PF 1.46/1.94/1.52 beats book all eras); deployed together with the 20x wallet so expression never self-cannibalizes"
   }
 }

--- a/tests/test_seller_flow_boost.py
+++ b/tests/test_seller_flow_boost.py
@@ -86,3 +86,25 @@ def test_wyckoff_phase_boost_parity():
         assert "wyckoff_phase_C_accum" in src
     enrich = LV[LV.index("Step 3e"):LV.index("Step 4:")]
     assert "wyckoff_phase_dir" in enrich
+
+
+def test_rotation_calm_boost_parity():
+    """Boost 7 (2026-08-06): rotation-calm long boost, capex-scoped, present in
+    both engines, enabled live, metadata enrichment carries stables_rot_rising."""
+    for src in (BT, LV):
+        assert "rotation_calm_boost" in src
+        assert "rotation_calm stables_rot_rising=0" in src
+    enrich = LV[LV.index("Step 3e"):LV.index("Step 4:")]
+    assert "stables_rot_rising" in enrich
+    cfg = json.loads((REPO / "configs/champion_paper.json").read_text())
+    assert cfg["rotation_calm_boost"]["enabled"] is True
+
+
+def test_config_wallet_is_nonbinding_scaled():
+    """2026-08-06 wallet directive: initial_cash 20x with position_sizing pcts
+    scaled /20 so per-trade DOLLARS are unchanged ($2,000 risk, $35K margin)."""
+    cfg = json.loads((REPO / "configs/champion_paper.json").read_text())
+    cash = cfg["initial_cash"]
+    ps = cfg["position_sizing"]
+    assert cash * ps["risk_per_trade_pct"] == 2000.0
+    assert cash * ps["max_margin_per_position_pct"] == 35000.0


### PR DESCRIPTION
Boost 7 validated (addendum 22) + 20x measurement wallet (user directive: edge discovery must not be gated by paper-capital artifacts). Dollar-identical sizing; parity tests green; smoke-verified.

Deploy note: requires one-time state.json cash top-up (+$1.9M) on the server between service stop and restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional 1.25× allocation boost for qualifying long positions during calm stablecoin rotation conditions.
  - Boost activity is now reflected in trade metadata and logs.
  - Trading tools can automatically use the configured starting cash when no custom amount is provided.

- **Configuration**
  - Updated paper-trading settings with a $2,000,000 wallet while preserving previous per-trade risk and margin limits.

- **Bug Fixes**
  - Improved handling of missing or invalid rotation data to prevent unintended sizing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->