### PR TITLE
feat: Wyckoff v2 shadow detectors — fix BC climax/breakout inversion, anchored spring, honest gauges

### DIFF
--- a/bin/live/coinbase_runner.py
+++ b/bin/live/coinbase_runner.py
@@ -2890,6 +2890,25 @@ class CoinbasePaperRunner:
                 "bullish_1d": self._safe_float(features.get("tf1d_wyckoff_bullish_score")),
                 "bearish_1d": self._safe_float(features.get("tf1d_wyckoff_bearish_score")),
                 "tf1d_bars": int(features.get("tf1d_daily_bars", 0) or 0),
+                # --- HONEST GAUGES (2026-08-20 audit): the score/tf*_score
+                # fields above are rolling MAXIMA (24h carry / 42d / 90d
+                # buffer max). event_now is the per-bar truth (0 = nothing
+                # active); event_age_h dates the newest event; *_raw are the
+                # pre-arbitration directional sides (net zeroes the loser).
+                "event_now": self._safe_float(features.get("wyckoff_event_now")),
+                "event_age_h": self._safe_float(features.get("wyckoff_event_age_h", -1.0)),
+                "bullish_4h_raw": self._safe_float(features.get("tf4h_wyckoff_bullish_raw")),
+                "bearish_4h_raw": self._safe_float(features.get("tf4h_wyckoff_bearish_raw")),
+                "bullish_1d_raw": self._safe_float(features.get("tf1d_wyckoff_bullish_raw")),
+                "bearish_1d_raw": self._safe_float(features.get("tf1d_wyckoff_bearish_raw")),
+                # v2 SHADOW detectors (data collection; not in trading path)
+                "shadow_v2": {
+                    "bc_v2": bool(features.get("wyckoff_bc_v2", False)),
+                    "bc_v2_confirmed": bool(features.get("wyckoff_bc_v2_confirmed", False)),
+                    "sc_v2": bool(features.get("wyckoff_sc_v2", False)),
+                    "sc_v2_confirmed": bool(features.get("wyckoff_sc_v2_confirmed", False)),
+                    "spring_b_anchored": bool(features.get("wyckoff_spring_b_anchored", False)),
+                },
                 "phase": features.get("wyckoff_phase_abc", "neutral"),
                 "sequence_position": int(features.get("wyckoff_sequence_position", 0) or 0),
                 "events": {

--- a/bin/live/live_feature_computer.py
+++ b/bin/live/live_feature_computer.py
@@ -1655,6 +1655,19 @@ class LiveFeatureComputer:
             if 'wyckoff_bearish_score' in buf_copy.columns:
                 out['wyckoff_bearish_score'] = float(recent_window['wyckoff_bearish_score'].max())
 
+            # Honest current-state extras (2026-08-20 audit): wyckoff_event_now
+            # (per-bar max, 0 when quiet) already flows via the generic column
+            # loop above; add the age of the newest active event so displays
+            # can label carried-forward maxima ("BC, 9h ago") instead of
+            # presenting them as live readings. Display/logging only.
+            if 'wyckoff_event_now' in buf_copy.columns:
+                active_idx = buf_copy.index[buf_copy['wyckoff_event_now'] > 0]
+                if len(active_idx) > 0:
+                    age = (buf_copy.index[-1] - active_idx[-1]) / pd.Timedelta(hours=1)
+                    out['wyckoff_event_age_h'] = float(age)
+                else:
+                    out['wyckoff_event_age_h'] = -1.0  # no event in buffer
+
             # Event history + conviction
             self.last_wyckoff_event_history = self._wyckoff_event_history(buf_copy, max_events=20)
             self.last_wyckoff_conviction = self._wyckoff_conviction_breakdown(last)
@@ -1771,6 +1784,9 @@ class LiveFeatureComputer:
                 # Graded bullish/bearish scores (replace binary M1/M2)
                 out['tf1d_wyckoff_bullish_score'] = ctx_1d.bullish_score
                 out['tf1d_wyckoff_bearish_score'] = ctx_1d.bearish_score
+                # Raw pre-arbitration sides (2026-08-20) — see 4H note.
+                out['tf1d_wyckoff_bullish_raw'] = ctx_1d.raw_bullish_score
+                out['tf1d_wyckoff_bearish_raw'] = ctx_1d.raw_bearish_score
 
                 # Keep M1/M2 for backward compat but now derived from context
                 out['tf1d_wyckoff_m1_signal'] = 1 if ctx_1d.bullish_score > 0.1 else 0
@@ -1804,6 +1820,11 @@ class LiveFeatureComputer:
                 # 4H scores
                 out['tf4h_wyckoff_bullish_score'] = htf_context_4h.bullish_score
                 out['tf4h_wyckoff_bearish_score'] = htf_context_4h.bearish_score
+                # Raw pre-arbitration sides (2026-08-20): net-dominance zeroes
+                # the losing side, so "bullish 0.000" can mean either "no
+                # evidence" or "netted away". Log the raw maxes for honesty.
+                out['tf4h_wyckoff_bullish_raw'] = htf_context_4h.raw_bullish_score
+                out['tf4h_wyckoff_bearish_raw'] = htf_context_4h.raw_bearish_score
 
                 confs_4h = []
                 for e in ALL_EVENTS:

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -367,6 +367,22 @@ export interface WyckoffData {
   bullish_1d?: number;
   bearish_1d?: number;
 
+  // Honest gauges (2026-08-20 audit): score/tf*_score above are rolling
+  // MAXIMA (24h carry / 42d / 90d); event_now is the per-bar truth.
+  event_now?: number;           // per-bar max event confidence, 0 = quiet
+  event_age_h?: number;         // hours since newest event, -1 = none in buffer
+  bullish_4h_raw?: number;      // pre-arbitration sides (net zeroes the loser)
+  bearish_4h_raw?: number;
+  bullish_1d_raw?: number;
+  bearish_1d_raw?: number;
+  shadow_v2?: {                 // v2 shadow detectors (data collection only)
+    bc_v2?: boolean;
+    bc_v2_confirmed?: boolean;
+    sc_v2?: boolean;
+    sc_v2_confirmed?: boolean;
+    spring_b_anchored?: boolean;
+  };
+
   // NEW: Cycle tracking
   cycle_start?: string;
   cycle_duration_hours?: number;

--- a/dashboard/src/components/dashboard/WyckoffCycle.tsx
+++ b/dashboard/src/components/dashboard/WyckoffCycle.tsx
@@ -186,8 +186,8 @@ const EVENT_META: Record<string, EventMeta> = {
     ],
   },
   ut: {
-    short: 'UT',
-    label: 'Upthrust',
+    short: 'UT / UTAD',
+    label: 'Upthrust (incl. UTAD)',
     type: 'distrib',
     explanation:
       'A fake breakout above the distribution range that reverses within 3 bars on a volume spike. Designed to trap late buyers and trigger breakout stops. The classic "bull trap."',
@@ -279,7 +279,9 @@ const PHASE_GROUPS: PhaseGroup[] = [
     sublabel: 'Distribution',
     color: 'text-orange-400',
     borderColor: 'border-orange-500/20',
-    events: ['sow', 'ut', 'utad'],
+    // Honesty fix 2026-08-20: UT and UTAD are currently one detection
+    // (bit-identical fires per audit) — shown as a single merged chip.
+    events: ['sow', 'ut'],
     description:
       'Smart money distributes within the range. Upthrusts trap late buyers. SOW proves supply exceeds demand.',
   },
@@ -696,8 +698,29 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
             {activeCount} Active
           </Badge>
         )}
-        {wyckoff.tf1d_m1_signal === 1 && <Badge variant="green">M1 Accum</Badge>}
-        {wyckoff.tf1d_m2_signal === 1 && <Badge variant="red">M2 Distrib</Badge>}
+        {/* Honesty fix 2026-08-20: the m1/m2 flags fire at raw-margin > 0.1
+            (very low), so a weak echo lit a solid red "M2 Distrib" during
+            rallies. Show the graded net value; solid color only when the net
+            side actually dominates (> 0.3, same bar as phase detection). */}
+        {(() => {
+          const netBull = wyckoff.bullish_1d ?? 0;
+          const netBear = wyckoff.bearish_1d ?? 0;
+          if (wyckoff.tf1d_m1_signal === 1) {
+            return (
+              <Badge variant={netBull > 0.3 ? 'green' : 'neutral'}>
+                M1 Accum {(netBull * 100).toFixed(0)}%{netBull <= 0.3 ? ' (weak)' : ''}
+              </Badge>
+            );
+          }
+          if (wyckoff.tf1d_m2_signal === 1) {
+            return (
+              <Badge variant={netBear > 0.3 ? 'red' : 'neutral'}>
+                M2 Distrib {(netBear * 100).toFixed(0)}%{netBear <= 0.3 ? ' (weak)' : ''}
+              </Badge>
+            );
+          }
+          return null;
+        })()}
       </div>
 
       {/* HTF Structural Bias Summary — most important at a glance */}
@@ -990,13 +1013,30 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
           Multi-Timeframe Peak Event Confidence
         </div>
         <p className="text-[10px] text-slate-700 mb-3">
-          Wyckoff is primarily a higher-timeframe structural tool — 1D and 4H scores matter most for identifying accumulation/distribution phases. 1H events are tactical entry triggers that fire within the HTF context. A 1H score of 0 is normal between events.
+          These are running MAXIMA over their windows, not live readings — they cannot fall while a past event sits in the buffer. The &ldquo;Now&rdquo; line below is the per-bar truth.
         </p>
+        {/* Honesty fix 2026-08-20: per-bar current state, 0 when quiet */}
+        {wyckoff.event_now != null && (
+          <div className="text-[11px] font-mono mb-3 px-2 py-1.5 rounded bg-white/[0.03] border border-white/[0.05]">
+            <span className={wyckoff.event_now > 0 ? 'text-cyan-300' : 'text-slate-500'}>
+              Now: {(wyckoff.event_now * 100).toFixed(0)}%
+              {wyckoff.event_now === 0 && ' — no event active on this bar'}
+            </span>
+            {(wyckoff.event_age_h ?? -1) >= 0 && (
+              <span className="text-slate-600">
+                {' '}· last event {Math.round(wyckoff.event_age_h!)}h ago
+              </span>
+            )}
+            {(wyckoff.event_age_h ?? -1) < 0 && (
+              <span className="text-slate-600"> · no event in buffer</span>
+            )}
+          </div>
+        )}
         <div className="grid grid-cols-3 gap-3">
           <div>
             <Gauge
               value={score1d}
-              label="1D Macro"
+              label="1D Macro (90d max)"
               colorStops={[
                 'bg-rose-500',
                 'bg-amber-400',
@@ -1007,13 +1047,16 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
             />
             {wyckoff.tf1d_bars != null && (
               <div className="text-[9px] text-slate-700 text-center mt-1">
-                {wyckoff.tf1d_bars}/20 daily bars
+                {wyckoff.tf1d_bars} daily bars
+                {wyckoff.tf1d_bars < 100 && (
+                  <span className="text-amber-500/70"> · deep context OFF</span>
+                )}
               </div>
             )}
           </div>
           <Gauge
             value={score4h}
-            label="4H Structure"
+            label="4H Structure (42d max)"
             colorStops={[
               'bg-rose-500',
               'bg-amber-400',
@@ -1024,7 +1067,7 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
           />
           <Gauge
             value={score1h}
-            label="1H Trigger"
+            label="1H Trigger (24h carry)"
             colorStops={[
               'bg-rose-500',
               'bg-amber-400',
@@ -1047,10 +1090,13 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
           </p>
           <div className="grid grid-cols-3 gap-3">
             {[
-              { label: '1D', bull: wyckoff.bullish_1d ?? 0, bear: wyckoff.bearish_1d ?? 0 },
-              { label: '4H', bull: wyckoff.bullish_4h ?? 0, bear: wyckoff.bearish_4h ?? 0 },
-              { label: '1H', bull: wyckoff.bullish_1h ?? 0, bear: wyckoff.bearish_1h ?? 0 },
-            ].map(({ label, bull, bear }) => (
+              { label: '1D', bull: wyckoff.bullish_1d ?? 0, bear: wyckoff.bearish_1d ?? 0,
+                bullRaw: wyckoff.bullish_1d_raw, bearRaw: wyckoff.bearish_1d_raw },
+              { label: '4H', bull: wyckoff.bullish_4h ?? 0, bear: wyckoff.bearish_4h ?? 0,
+                bullRaw: wyckoff.bullish_4h_raw, bearRaw: wyckoff.bearish_4h_raw },
+              { label: '1H', bull: wyckoff.bullish_1h ?? 0, bear: wyckoff.bearish_1h ?? 0,
+                bullRaw: undefined, bearRaw: undefined },
+            ].map(({ label, bull, bear, bullRaw, bearRaw }) => (
               <div key={label} className="p-2 bg-white/[0.02] rounded-lg border border-white/[0.04]">
                 <div className="text-[9px] text-slate-600 text-center mb-1">{label}</div>
                 <div className="flex justify-between items-center gap-1">
@@ -1059,6 +1105,11 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
                       {(bull * 100).toFixed(1)}%
                     </div>
                     <div className="text-[8px] text-emerald-600">Bull</div>
+                    {/* Honesty fix 2026-08-20: net-dominance zeroes the losing
+                        side; the raw max shows evidence that was netted away */}
+                    {bullRaw != null && bullRaw > bull && (
+                      <div className="text-[8px] text-slate-600 font-mono">raw {(bullRaw * 100).toFixed(0)}%</div>
+                    )}
                   </div>
                   <div className="w-px h-4 bg-white/[0.06]" />
                   <div className="text-center flex-1">
@@ -1066,6 +1117,9 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
                       {(bear * 100).toFixed(1)}%
                     </div>
                     <div className="text-[8px] text-rose-600">Bear</div>
+                    {bearRaw != null && bearRaw > bear && (
+                      <div className="text-[8px] text-slate-600 font-mono">raw {(bearRaw * 100).toFixed(0)}%</div>
+                    )}
                   </div>
                 </div>
               </div>
@@ -1080,7 +1134,7 @@ export default function WyckoffCycle({ wyckoff, oracle }: WyckoffCycleProps) {
       {/* Overall Confidence */}
       {wyckoff.event_confidence != null && wyckoff.event_confidence > 0 && (
         <div className="mt-3 flex items-center gap-2 text-xs">
-          <span className="text-slate-600">Peak Event Confidence:</span>
+          <span className="text-slate-600">Peak Event Confidence (24h max):</span>
           <Badge variant={wyckoff.event_confidence >= 0.8 ? 'green' : wyckoff.event_confidence >= 0.5 ? 'cyan' : 'yellow'}>
             {(wyckoff.event_confidence * 100).toFixed(1)}%
           </Badge>

--- a/docs/knowledge/cme_seller_flow_replication_2026_08_20.md
+++ b/docs/knowledge/cme_seller_flow_replication_2026_08_20.md
@@ -1,0 +1,31 @@
+# CME Seller-Flow Replication Study — 2026-08-20
+
+**Data**: CME BTC futures via Databento (~$11 of $40 credit): 1m bars 2021-01→2026-08 (`data/databento/btc_fut_1m_2021_2026.parquet`), 875K tick trades w/ aggressor side 2026-02→08 (`btc_fut_trades_2026.parquet`). Basis vs our spot store: mean +0.41%, std 0.29% — data real/aligned.
+**Question**: does wick_trap's seller-flow boost (1.25× on taker_imbalance≤0 flushes, validated once on OKX/Binance-Vision data) replicate on independent institutional flow?
+
+## Q1 — Does the live signal match real flow? NO, and the reason is a LIVE BUG
+Live `taker_imbalance` vs CME hourly aggressor imbalance (1,255 overlap hours, Jun–Aug 2026):
+**pearson r = 0.017 (p=0.56), sign agreement 52% = coin flip.** No lag (−3..+3h) or smoothing (4/8/24h) fixes it.
+**Root cause found** (`live_feature_computer.py:2395`): live taker_imbalance = `(ratio−1)/max(ratio,0.01)` on OKX `fetch_all_current` — a once-per-hour POINT SNAPSHOT. autocorr(1h)=0.007 (white noise), std 0.27.
+The VALIDATED store feature is different: Binance Vision `sum_taker_long_short_vol_ratio`, a true 1h aggregate — autocorr 0.125, std 0.075, 28% of bars ≤0 (`derivatives_data_backfill_method.md`).
+**⇒ The live boost condition fires on ~white noise that is NOT the variable the boost was validated on.** Same class of live/backtest divergence as audit #7 (A2). Sensor repair needed: aggregate OKX taker volume over the full hour (or persist+integrate snapshots) to match the store definition.
+
+## Q2 — Does the THESIS replicate on institutional flow? DIRECTIONALLY YES (underpowered)
+CME 1h bars Feb–Aug 2026, wick-trap-shaped flushes (lower_wick≥0.35, vol_z≥1.5, 20-bar low probe): n=37.
+| cohort | n | fwd 72h | fwd 168h |
+|---|---|---|---|
+| flush + CME SELLER aggression | 25 | **+0.29%** | **+0.41%** |
+| flush + CME buyer aggression | 12 | −0.52% | −1.73% |
+| baseline (all bars) | 3510 | −0.30% | — |
+Binary split matches the boost thesis on a venue and months never used in any prior study. Caveats: n small; graded version flat (spearman 0.04, p=0.80) — it's a sign effect, not a dose-response.
+
+## Q3 — Live wick_trap entries vs CME flow (n=7, anecdotal)
+Winners (n=2) mean CME imbalance **−0.088** (sellers capitulating); losers (n=5) **+0.137**. The worst entry (08-16, −$602) had CME imb **+0.89** — extreme buyer aggression at the "flush" = trap signature. Direction consistent with Q2 and the original study.
+
+## Verdicts
+1. **Thesis: REPLICATES directionally** on fresh institutional data (Q2+Q3 agree with the OKX-era validation). The seller-flow idea is market structure, not a venue artifact.
+2. **Live implementation: BROKEN** — the boost keys on a snapshot that doesn't measure hourly flow. The boost's live effect to date is essentially random sizing noise on wick_trap. Fix is a sensor repair (hourly aggregation), then the validated condition actually binds live.
+3. Boost-shaped follow-up (after repair): none needed immediately; re-validate the boost's live hit-rate once the repaired feature accumulates ~4-8 weeks.
+4. NOT proposed: any filter/gate (Rules 7-10), any CME live feed (cost; revisit only if the repaired OKX aggregate still diverges from CME on a longer overlap).
+
+*Method note: all tests on fresh data (CME Feb–Aug 2026 + live logs); zero spent folds reused. Study data retained in data/databento/ (purchased, reusable); scratch deleted.*

--- a/docs/knowledge/mancini_transfer_map_2026_08_20.md
+++ b/docs/knowledge/mancini_transfer_map_2026_08_20.md
@@ -1,0 +1,31 @@
+# Mancini→BM Transfer Map + 75/15/10 Exit A/B — 2026-08-20
+
+**Source**: full read-only inventory of the Mancini ES bot (~/Mancini bot/Mancini; corpus baseline +$43.6K/−$5.2K DD, 2024-07→2026-02). Its core trade IS wick_trap (sweep below significant low → reclaim → confirm) — evidence unusually transferable.
+
+## 75/15/10 exit A/B (BM full backtest 2020-2024, all archetypes, forced override)
+Variant: 75% @1R, 15% @2R, 10% runner, trail 3.5×ATR after T1, NO breakeven (BM retracted 2×).
+| | base 10/30/50 | 75/15/10 |
+|---|---|---|
+| PnL | $268.9K | $240.9K (−10%) |
+| PF/Sharpe | 1.41/1.53 | 1.39/1.50 |
+| MaxDD | −16.5% | −15.2% (better) |
+| trades | 3512 | 2694 (−23%) |
+| avg/trade | $77 | $89 (+17%); avg win +37%, avg loss smaller |
+**VERDICT: REJECT as straight swap.** Per-trade quality improves everywhere; total PnL falls because longer holds block position slots (−23% turnover). BM PnL = turnover × small edge. A fair re-test requires runner-slot demotion (Mancini's fix, +$10.7K there) — not justified while entry quality is the known leak (their 5y sweep verbatim: "every configuration has every year red regardless of exit tuning. The issue isn't exits — it's entry quality" = BM bucket-A finding).
+Method note: first A/B ran byte-identical (patched dead default_rules; real ladder lives in create_default_exit_config per-archetype). Golden-master lesson self-demonstrated.
+
+## Transfer candidates (evidence-backed, in priority order)
+1. **Sizing-inversion check** — their meta-label audit: tight stops = 33%-WR anti-tell; deep flushes = 80% WR + biggest winners; "size down on wide stops" RETIRED as inverted. BM sizes inversely to ATR-stop distance → may be shrinking deep-flush winners exactly the same way (cf. BM unified forward-test: tight stop stabbed 7/10). Pure backtest on existing data. NEXT STUDY.
+2. **Velocity-at-reclaim boost for wick_trap** — their dominant, regime-invariant quality signal (holds every year, 498k events; "gate on speed not the clock"). BM wick_trap has no velocity term. Boost-shaped.
+3. **Macro-event blackout** — measured: P(outsized bar) FOMC 95%/CPI 93%/NFP 70% vs 3% baseline; hard-block shipped there. BM trades through FOMC blind. Stand-down calendar, not a fusion filter.
+4. **Re-entry throttling** — un-freezing their accidental no-re-signal discipline cost −$15.1K on 2× entries. BM analog: trap_within_trend pileups (2+ open → PF 0.42). Per-archetype cooldown study.
+5. **Runner mechanics IF ever revisited**: T2 snapped to real levels; trail ratchets EOD-only (per-bar chase-trail was their "888 killer", exited before +404pts — BM's per-bar ATR chase is the same pattern); runners demote to background slot.
+
+## Anti-transfer (their closed doors that map to ours)
+- Regime gate on full stack: −$9.9K there; 0/9 filters here. Convergent.
+- **Order-flow absorption from aggregate trades: KILLED on adversarial verification there** — read their post-mortem before building BM's B-tier absorption_flag.
+- Levels-as-targets: premature exits (+67→+50 avg win). Caution for level-snapped targets.
+- Non-price data (TICK/VPIN/CVD): all killed. Their edge source = human newsletter (engine-only is −$7K 2021-24); BM's = structural detection (fusion is anti-signal). Neither engine survives on generic indicators.
+
+## Process rules adopted from their ledger
+Golden-master before trusting any A/B (demonstrated today); count entries before believing results; one concern per change; pre-registered gates; None-sentinel replay flags.

--- a/docs/knowledge/mancini_transfer_map_2026_08_20.md
+++ b/docs/knowledge/mancini_transfer_map_2026_08_20.md
@@ -12,6 +12,7 @@ Variant: 75% @1R, 15% @2R, 10% runner, trail 3.5×ATR after T1, NO breakeven (BM
 | trades | 3512 | 2694 (−23%) |
 | avg/trade | $77 | $89 (+17%); avg win +37%, avg loss smaller |
 **VERDICT: REJECT as straight swap.** Per-trade quality improves everywhere; total PnL falls because longer holds block position slots (−23% turnover). BM PnL = turnover × small edge. A fair re-test requires runner-slot demotion (Mancini's fix, +$10.7K there) — not justified while entry quality is the known leak (their 5y sweep verbatim: "every configuration has every year red regardless of exit tuning. The issue isn't exits — it's entry quality" = BM bucket-A finding).
+**$2M-wallet control (same day)**: identical trade counts (3512/2694) and ratios at 20x capital — margin was NEVER the constraint. The −818 trades are STRUCTURAL (archetype/direction position slots occupied by longer holds), so the turnover loss holds at any wallet size and equals lost data points under the edge-discovery mandate. Runner-slot demotion is the hard prerequisite for any long-runner exit scheme in BM.
 Method note: first A/B ran byte-identical (patched dead default_rules; real ladder lives in create_default_exit_config per-archetype). Golden-master lesson self-demonstrated.
 
 ## Transfer candidates (evidence-backed, in priority order)

--- a/docs/knowledge/wyckoff_audit.md
+++ b/docs/knowledge/wyckoff_audit.md
@@ -1180,3 +1180,28 @@ BOMS-bear), real backtest+costs+exits (not fwd-returns), CPCV, and CROSS-ASSET w
 detector (SPX/NDX/Gold) — if the same HTF-BOMS-gates-LTF effect holds on 4 assets, that beats the
 per-asset small-n problem. This is the first result worth escalating in a while. Still: detection
 fix enabled a fair test; the pulse is real-looking but unproven.
+
+### 2026-08-20 addendum 53 — Live-display audit + v2 SHADOW detectors (branch feat/wyckoff-v2-shadow-detectors)
+
+Read-only live audit (agent, server untouched): data feed REAL (mean basis
+−0.0015% vs Coinbase spot, fresh <2min, zero repaint over 61 truncated
+recomputes). But: **BC INVERTED live** (fwd +1.20%/72h, fires on rallies —
+fired 3x on 08-19 right before +7%; poisons bearish score → m2_signal=1 during
+rallies via net-dominance), headline scores are rolling MAXIMA (24h/42d/90d)
+displayed as live gauges (0.9933 pinned; largest fusion domain — a Lesson #54
+mechanism), phase machine 96.6% in {A,neutral} over 6 months (known
+bottleneck, unchanged), UT/UTAD bit-identical, SC/AR/AS/ST coin-flip fwd.
+ROOT CAUSE of BC inversion found in code: 3 gates, no reversal requirement,
+and _range_position is CLOSE-based → rejection tops (close low) FAIL at_highs;
+only strong-close breakouts can fire. Wick gate cannot be restored (fix #2
+history: euphoric tops close at highs).
+FIX (shadow columns only, v1 untouched, isolation proven): detect_climax_v2 —
+gates on the EXTREME reached + (rejection NOW → immediate) or (reversal within
+5 bars → confirmed, stamped causally late). V12 replay: bc_v2_confirmed fwd
++0.40/+0.24 vs v1 +1.08/+1.92 (baseline +0.45/+1.11) — direction fixed.
+spring_b_anchored (add.31 implemented, post-SM subset): +1.18/+2.25 n=100 vs
+plain +0.90/+1.48 n=146 — anchoring keeps the good springs. wyckoff_event_now/
+age_h + raw context sides added for display honesty. SC v2 reads as bear-STATE
+(−0.62/72h), not a buy trigger. Deep-daily buffer left OFF (2026-07-20 verdict
+stands). NEXT: collect live shadow data; promotion to decision inputs requires
+its own validation study (boost-shaped per Rules 7-10, never a filter).

--- a/engine/wyckoff/events.py
+++ b/engine/wyckoff/events.py
@@ -452,6 +452,13 @@ class WyckoffHTFContext:
     dominant_direction: str  # "bullish", "bearish", "neutral"
     recent_events: Dict[str, float]  # {event_name: max_confidence} from recent bars
     timeframe: str          # "1D", "4H", etc. for logging
+    # Raw pre-arbitration sides (2026-08-20): net-dominance forces the losing
+    # side to exactly 0.0, so downstream displays can't tell "no bullish
+    # evidence" from "bullish evidence netted away". These carry the raw maxes
+    # for display/logging; net bullish_score/bearish_score stay authoritative
+    # for decisions. Defaults keep older constructors valid.
+    raw_bullish_score: float = 0.0
+    raw_bearish_score: float = 0.0
 
 
 def _rolling_z_score(series: pd.Series, window: int = 20) -> pd.Series:
@@ -644,6 +651,109 @@ def detect_buying_climax(df: pd.DataFrame, cfg: dict) -> Tuple[pd.Series, pd.Ser
     confidence = confidence.fillna(0.0) * detected
 
     return detected, confidence
+
+
+def detect_climax_v2(df: pd.DataFrame, cfg: dict,
+                     side: str = "buying") -> Tuple[pd.Series, pd.Series, pd.Series]:
+    """
+    v2 SHADOW climax detector — disambiguates climax from breakout/breakdown.
+
+    Background (wyckoff_audit.md + live audit 2026-08-20): the v1 BC/SC
+    detectors share 3 hard gates (volume_z, long range_position, range_z) with
+    NO reversal requirement, so an SOS breakout bar and a Buying Climax are
+    indistinguishable — BC's forward returns match SOS's (+1.2%/72h), i.e. it
+    fires on rallies. The wick gate can't simply be restored: real euphoric
+    tops (Apr/Nov 2021) close AT their highs and were only caught after the
+    wick gate was demoted (see "6 Fixes Applied", fix #2). The only honest
+    disambiguator for a strong-close candidate is WHAT HAPPENS NEXT:
+        reversal within k bars  -> climax   (confirmed, stamped late)
+        continuation            -> breakout (neither column fires)
+
+    Emits three causal series:
+        detected   — immediate fire: v1 gates AND rejection evidence on the
+                     bar itself (wick quality >= wick_min OR close in the
+                     opposite third of the bar's range).
+        confidence — v1-style confidence, only on immediate fires.
+        confirmed  — a gate-passing candidate (with or without rejection)
+                     whose reversal completed: for buying, a close BELOW the
+                     candidate bar's low within confirm_bars; for selling, a
+                     close ABOVE the candidate bar's high. Stamped at the
+                     CONFIRMATION bar — on truncated data the flag simply
+                     hasn't appeared yet, so earlier bars never repaint.
+
+    SHADOW CONTRACT: these columns are data-collection only. They are NOT in
+    _ACCUM_EVENTS/_DISTRIB_EVENTS, so they cannot touch directional scores,
+    the state machine, phases, or any live consumer.
+    """
+    if 'volume_z' not in df.columns:
+        df['volume_z'] = _rolling_z_score(df['volume'], window=20)
+
+    bar_range = df['high'] - df['low']
+    range_z = _rolling_z_score(bar_range, window=20)
+    close_loc = ((df['close'] - df['low']) / (bar_range + 1e-9)).clip(0, 1)
+
+    volume_z_min = cfg.get('climax_v2_volume_z_min', 2.5)
+    range_z_min = cfg.get('climax_v2_range_z_min', 1.5)
+    wick_min = cfg.get('climax_v2_wick_min', 0.5)
+    confirm_bars = cfg.get('climax_v2_confirm_bars', 5)
+    range_lookback = cfg.get('climax_v2_range_lookback', 50)
+
+    extreme_volume = df['volume_z'] > volume_z_min
+    wide_range = range_z > range_z_min
+
+    # Position of the EXTREME reached, not the close. v1's _range_position is
+    # close-based, so a genuine rejection top (which closes low) fails the
+    # "at_highs" gate — the structural reason v1 BC only catches strong-close
+    # bars (breakouts). A climax is defined by where price REACHED.
+    rolling_high = df['high'].rolling(range_lookback).max()
+    rolling_low = df['low'].rolling(range_lookback).min()
+    range_size = rolling_high - rolling_low + 1e-9
+
+    if side == "buying":
+        extreme_reach = ((df['high'] - rolling_low) / range_size).clip(0, 1)
+        at_extreme = extreme_reach > cfg.get('bc_range_pos_min', 0.8)
+        wick_quality = _wick_quality(df, direction='upper')
+        # rejection NOW: real upper wick or a close in the lower third
+        rejection = (wick_quality >= wick_min) | (close_loc <= 0.35)
+        extreme_pos_conf = extreme_reach
+    else:
+        extreme_reach = ((df['low'] - rolling_low) / range_size).clip(0, 1)
+        at_extreme = extreme_reach < cfg.get('sc_range_pos_max', 0.2)
+        wick_quality = _wick_quality(df, direction='lower')
+        # absorption NOW: real lower wick or a close in the upper third
+        rejection = (wick_quality >= wick_min) | (close_loc >= 0.65)
+        extreme_pos_conf = 1.0 - extreme_reach
+
+    candidate = (extreme_volume & at_extreme & wide_range).fillna(False)
+    detected = (candidate & rejection).fillna(False)
+
+    confidence = (
+        (df['volume_z'] / 5.0).clip(0, 1) * 0.30 +
+        extreme_pos_conf.clip(0, 1) * 0.20 +
+        (range_z / 3.0).clip(0, 1) * 0.20 +
+        wick_quality.clip(0, 1) * 0.30
+    )
+    confidence = confidence.fillna(0.0) * detected
+
+    # Delayed confirmation — causal by construction: we only ever stamp a bar
+    # AFTER the candidate, using closes up to that bar. Truncating the frame
+    # removes future stamps without altering past ones (no repaint).
+    confirmed = pd.Series(False, index=df.index)
+    closes = df['close'].values
+    cand_idx = np.flatnonzero(candidate.values)
+    n = len(df)
+    for i in cand_idx:
+        ref_low = df['low'].values[i]
+        ref_high = df['high'].values[i]
+        for j in range(i + 1, min(i + 1 + confirm_bars, n)):
+            if side == "buying" and closes[j] < ref_low:
+                confirmed.iloc[j] = True
+                break
+            if side == "selling" and closes[j] > ref_high:
+                confirmed.iloc[j] = True
+                break
+
+    return detected.astype(bool), confidence, confirmed
 
 
 def detect_automatic_rally(df: pd.DataFrame, cfg: dict,
@@ -1403,6 +1513,8 @@ def create_wyckoff_context(df: pd.DataFrame, lookback: int = 3,
         dominant_direction=direction,
         recent_events=recent,
         timeframe=timeframe,
+        raw_bullish_score=raw_bullish_score,
+        raw_bearish_score=raw_bearish_score,
     )
     logger.info(f"WyckoffHTFContext({timeframe}): phase={phase}, "
                 f"bullish={bullish_score:.3f}, bearish={bearish_score:.3f}, "
@@ -1664,6 +1776,18 @@ def detect_all_wyckoff_events(df: pd.DataFrame, cfg: Optional[dict] = None,
     df['wyckoff_lps'], df['wyckoff_lps_confidence'] = detect_last_point_of_support(df, cfg)
     df['wyckoff_lpsy'], df['wyckoff_lpsy_confidence'] = detect_last_point_of_supply(df, cfg)
 
+    # ------------------------------------------------------------------
+    # v2 SHADOW columns (2026-08-20) — data collection ONLY. Deliberately
+    # NOT in _ACCUM_EVENTS/_DISTRIB_EVENTS: they cannot touch directional
+    # scores, the state machine, phases, or any live consumer. Promotion to
+    # decision inputs requires a passing validation study first.
+    # ------------------------------------------------------------------
+    if cfg.get('shadow_v2_enabled', True):
+        (df['wyckoff_bc_v2'], df['wyckoff_bc_v2_confidence'],
+         df['wyckoff_bc_v2_confirmed']) = detect_climax_v2(df, cfg, side='buying')
+        (df['wyckoff_sc_v2'], df['wyckoff_sc_v2_confidence'],
+         df['wyckoff_sc_v2_confirmed']) = detect_climax_v2(df, cfg, side='selling')
+
     # Determine phase and sequence (before SM so phase exists)
     df['wyckoff_phase_abc'] = _determine_wyckoff_phase(df)
     df['wyckoff_sequence_position'] = _compute_sequence_position(df)
@@ -1680,12 +1804,49 @@ def detect_all_wyckoff_events(df: pd.DataFrame, cfg: Optional[dict] = None,
         df['wyckoff_phase_dir'] = 'neutral'
         df['wyckoff_context'] = 'none'
 
+    # Anchored spring shadow (wyckoff_audit add.31: springs fire at fresh
+    # 20-bar lows mid-trend, not at structural range lows — "the highest-
+    # leverage fix: anchor to the 50-bar swing low; test, do NOT wire").
+    # Computed AFTER state-machine validation so it is a strict subset of the
+    # final wyckoff_spring_b column (the one every consumer sees). spring_b
+    # stamps at the confirmation bar; its candidate bar sits recovery_bars
+    # earlier, so all anchor inputs are shifted to align.
+    if cfg.get('shadow_v2_enabled', True):
+        recovery_bars = cfg.get('spring_b_recovery_bars', 3)
+        tr = pd.concat([
+            df['high'] - df['low'],
+            (df['high'] - df['close'].shift(1)).abs(),
+            (df['low'] - df['close'].shift(1)).abs(),
+        ], axis=1).max(axis=1)
+        atr14 = tr.rolling(14).mean()
+        prior_low50 = df['low'].shift(1).rolling(50).min()
+        cand_low = df['low'].shift(recovery_bars)
+        anchor_tol = cfg.get('spring_anchor_atr_tol', 1.0)
+        anchored_ok = (
+            (cand_low - prior_low50.shift(recovery_bars)).abs()
+            <= anchor_tol * atr14.shift(recovery_bars)
+        ).fillna(False)
+        df['wyckoff_spring_b_anchored'] = (
+            df['wyckoff_spring_b'].astype(bool) & anchored_ok
+        )
+
     # Apply higher-timeframe confidence modulation (on SM-validated events only)
     if htf_context is not None:
         df = _apply_htf_modulation(df, htf_context)
 
     # Compute directional scores (after SM + HTF modulation)
     df = _compute_directional_scores(df)
+
+    # Honest current-state gauge (2026-08-20 live audit): the legacy display
+    # scores are rolling/window MAXIMA (24h carry, 42d/90d buffer max) that can
+    # never fall while an old event sits in the buffer. wyckoff_event_now is
+    # the per-bar max SM-validated event confidence — exactly 0 on bars where
+    # no event is active. Display/logging only; no live consumer reads it.
+    _v1_conf_cols = [f'wyckoff_{e}_confidence' for e in _ACCUM_EVENTS + _DISTRIB_EVENTS
+                     if f'wyckoff_{e}_confidence' in df.columns]
+    df['wyckoff_event_now'] = (
+        df[_v1_conf_cols].fillna(0.0).max(axis=1) if _v1_conf_cols else 0.0
+    )
 
     # Log summary
     event_counts = {

--- a/tests/test_wyckoff_v2_climax.py
+++ b/tests/test_wyckoff_v2_climax.py
@@ -1,0 +1,241 @@
+"""
+Wyckoff v2 SHADOW detector tests — climax disambiguation (BC/SC v2),
+anchored spring, per-bar event_now score, raw context sides.
+
+Design contract (docs/knowledge/wyckoff_audit.md + live audit 2026-08-20):
+- A climax and a breakout share the same 3 hard gates (volume_z, range_pos,
+  range_z). They can only be told apart by rejection evidence on the bar
+  (wick / weak close) or by what happens NEXT (reversal => climax,
+  continuation => breakout). Requiring a wick alone was tried and REVERTED
+  (Apr/Nov 2021 euphoric tops close at their highs) — so v2 keeps the
+  original detector untouched and adds shadow columns:
+    wyckoff_bc_v2            immediate: gates + rejection evidence NOW
+    wyckoff_bc_v2_confirmed  delayed: candidate + reversal within k bars,
+                             stamped at the CONFIRMATION bar (never backfilled)
+    (sc_v2 mirror on the selling side)
+- Shadow columns must NOT feed scores / state machine / phase (data
+  collection only), and must be causal: truncated recompute == full compute
+  on the shared prefix.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from engine.wyckoff.events import (
+    detect_all_wyckoff_events,
+    detect_climax_v2,
+    create_wyckoff_context,
+)
+
+
+# ---------------------------------------------------------------- helpers
+def _flat_df(n=80, price=100.0, vol=1000.0, seed=7):
+    """Quiet tape: small ranges, stable volume."""
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    drift = rng.normal(0, 0.03, n).cumsum()
+    close = price + drift
+    open_ = close + rng.normal(0, 0.02, n)
+    high = np.maximum(open_, close) + 0.05
+    low = np.minimum(open_, close) - 0.05
+    volume = vol + rng.normal(0, 20, n)
+    return pd.DataFrame(
+        {"open": open_, "high": high, "low": low, "close": close, "volume": volume},
+        index=idx,
+    )
+
+
+def _spike_bar(df, i, kind):
+    """Overwrite bar i with a gate-passing spike (huge volume, wide range, at highs)."""
+    base = float(df["close"].iloc[i - 1])
+    hi, lo = base + 6.0, base - 0.5  # wide range, top of every lookback window
+    df.iloc[i, df.columns.get_loc("volume")] = 20000.0
+    df.iloc[i, df.columns.get_loc("open")] = base
+    df.iloc[i, df.columns.get_loc("high")] = hi
+    df.iloc[i, df.columns.get_loc("low")] = lo
+    if kind == "euphoric":        # closes at the high — breakout OR climax top
+        df.iloc[i, df.columns.get_loc("close")] = hi - 0.05
+    elif kind == "rejected":      # big upper wick, weak close
+        df.iloc[i, df.columns.get_loc("close")] = lo + 0.15 * (hi - lo)
+    return df, hi, lo
+
+
+def _continue_up(df, i, hi, k=6):
+    for j in range(i + 1, min(i + 1 + k, len(df))):
+        lvl = hi + 0.8 * (j - i)
+        df.iloc[j, df.columns.get_loc("open")] = lvl - 0.3
+        df.iloc[j, df.columns.get_loc("close")] = lvl
+        df.iloc[j, df.columns.get_loc("high")] = lvl + 0.1
+        df.iloc[j, df.columns.get_loc("low")] = lvl - 0.5
+    return df
+
+
+def _reverse_down(df, i, lo, k=3):
+    """Close below the candidate bar's low within k bars."""
+    for j in range(i + 1, i + 1 + k):
+        lvl = lo - 0.8 * (j - i)
+        df.iloc[j, df.columns.get_loc("open")] = lvl + 0.3
+        df.iloc[j, df.columns.get_loc("close")] = lvl
+        df.iloc[j, df.columns.get_loc("high")] = lvl + 0.5
+        df.iloc[j, df.columns.get_loc("low")] = lvl - 0.1
+    return df
+
+
+I = 65  # spike bar index (past all warmup windows)
+
+
+# ---------------------------------------------------------------- BC v2
+def test_breakout_is_not_bc_v2():
+    """Euphoric close + upward continuation => neither immediate nor confirmed."""
+    df, hi, lo = _spike_bar(_flat_df(), I, "euphoric")
+    df = _continue_up(df, I, hi)
+    det, conf, confirmed = detect_climax_v2(df.copy(), {}, side="buying")
+    assert not det.iloc[I], "breakout bar must not be immediate bc_v2"
+    assert not confirmed.any(), "continuation must never confirm a climax"
+
+
+def test_rejection_wick_is_immediate_bc_v2():
+    df, hi, lo = _spike_bar(_flat_df(), I, "rejected")
+    det, conf, confirmed = detect_climax_v2(df.copy(), {}, side="buying")
+    assert det.iloc[I], "gates + rejection wick must fire immediately"
+    assert conf.iloc[I] > 0
+
+
+def test_euphoric_top_confirmed_by_reversal():
+    """Apr/Nov-2021 shape: closes at high, reverses after. Confirmed at the
+    confirmation bar (close < candidate low), never at the event bar."""
+    df, hi, lo = _spike_bar(_flat_df(), I, "euphoric")
+    df = _reverse_down(df, I, lo, k=3)
+    det, conf, confirmed = detect_climax_v2(df.copy(), {}, side="buying")
+    assert not det.iloc[I], "euphoric close alone is ambiguous — no immediate fire"
+    conf_idx = confirmed[confirmed].index
+    assert len(conf_idx) >= 1, "reversal within k bars must confirm the climax"
+    assert conf_idx[0] > df.index[I], "confirmation stamps AFTER the event bar"
+
+
+def test_bc_v2_is_causal_no_repaint():
+    """Truncated recompute must equal full compute on the shared prefix."""
+    df, hi, lo = _spike_bar(_flat_df(), I, "euphoric")
+    df = _reverse_down(df, I, lo, k=3)
+    full_det, _, full_confirmed = detect_climax_v2(df.copy(), {}, side="buying")
+    for cut in (I + 1, I + 2, I + 3, I + 4):
+        part_det, _, part_confirmed = detect_climax_v2(df.iloc[:cut].copy(), {}, side="buying")
+        pd.testing.assert_series_equal(part_det, full_det.iloc[:cut], check_names=False)
+        pd.testing.assert_series_equal(
+            part_confirmed, full_confirmed.iloc[:cut], check_names=False
+        )
+
+
+# ---------------------------------------------------------------- SC v2 mirror
+def _spike_bar_down(df, i, kind):
+    base = float(df["close"].iloc[i - 1])
+    hi, lo = base + 0.5, base - 6.0
+    df.iloc[i, df.columns.get_loc("volume")] = 20000.0
+    df.iloc[i, df.columns.get_loc("open")] = base
+    df.iloc[i, df.columns.get_loc("high")] = hi
+    df.iloc[i, df.columns.get_loc("low")] = lo
+    if kind == "capitulation_close":   # closes at the low — breakdown OR capitulation
+        df.iloc[i, df.columns.get_loc("close")] = lo + 0.05
+    elif kind == "absorbed":           # long lower wick, strong close
+        df.iloc[i, df.columns.get_loc("close")] = hi - 0.15 * (hi - lo)
+    return df, hi, lo
+
+
+def test_breakdown_is_not_sc_v2():
+    """The live 63.3k 'SC' shape: closes at low, keeps falling => nothing."""
+    df, hi, lo = _spike_bar_down(_flat_df(), I, "capitulation_close")
+    for j in range(I + 1, I + 6):
+        lvl = lo - 0.8 * (j - I)
+        df.iloc[j, df.columns.get_loc("open")] = lvl + 0.3
+        df.iloc[j, df.columns.get_loc("close")] = lvl
+        df.iloc[j, df.columns.get_loc("high")] = lvl + 0.5
+        df.iloc[j, df.columns.get_loc("low")] = lvl - 0.1
+    det, conf, confirmed = detect_climax_v2(df.copy(), {}, side="selling")
+    assert not det.iloc[I]
+    assert not confirmed.any()
+
+
+def test_absorption_wick_is_immediate_sc_v2():
+    df, hi, lo = _spike_bar_down(_flat_df(), I, "absorbed")
+    det, conf, confirmed = detect_climax_v2(df.copy(), {}, side="selling")
+    assert det.iloc[I]
+
+
+def test_capitulation_confirmed_by_recovery():
+    df, hi, lo = _spike_bar_down(_flat_df(), I, "capitulation_close")
+    for j in range(I + 1, I + 4):   # close back above candidate high
+        lvl = hi + 0.8 * (j - I)
+        df.iloc[j, df.columns.get_loc("open")] = lvl - 0.3
+        df.iloc[j, df.columns.get_loc("close")] = lvl
+        df.iloc[j, df.columns.get_loc("high")] = lvl + 0.1
+        df.iloc[j, df.columns.get_loc("low")] = lvl - 0.5
+    det, conf, confirmed = detect_climax_v2(df.copy(), {}, side="selling")
+    assert not det.iloc[I]
+    assert confirmed.any()
+    assert confirmed[confirmed].index[0] > df.index[I]
+
+
+# ---------------------------------------------------------------- integration
+def test_shadow_columns_present_and_isolated():
+    """detect_all_wyckoff_events emits the shadow columns without changing
+    the v1 columns, scores, or phase (shadow = data collection only)."""
+    df, hi, lo = _spike_bar(_flat_df(120), I, "euphoric")
+    df = _continue_up(df, I, hi)
+    base = detect_all_wyckoff_events(df.copy())
+    for col in (
+        "wyckoff_bc_v2", "wyckoff_bc_v2_confidence", "wyckoff_bc_v2_confirmed",
+        "wyckoff_sc_v2", "wyckoff_sc_v2_confidence", "wyckoff_sc_v2_confirmed",
+        "wyckoff_spring_b_anchored", "wyckoff_event_now",
+    ):
+        assert col in base.columns, f"missing shadow column {col}"
+    # v1 unchanged: recompute with shadow columns dropped pre-pass is impossible
+    # to diff directly, so assert the invariant that shadow families are NOT in
+    # the directional scores: a breakout bar has bc(v1) fired but bearish score
+    # must be computable identically whether or not v2 columns exist.
+    assert base["wyckoff_bc"].iloc[I], "sanity: v1 BC still fires on the spike"
+    assert not base["wyckoff_bc_v2"].iloc[I], "v2 must not fire on the breakout"
+
+
+def test_event_now_zero_when_quiet():
+    df = _flat_df(120)
+    out = detect_all_wyckoff_events(df.copy())
+    quiet = out.iloc[30:50]
+    active = quiet[[c for c in quiet.columns
+                    if c.startswith("wyckoff_") and c.endswith("_confidence")
+                    and "_v2" not in c]].max(axis=1).fillna(0)
+    # event_now equals the per-bar max confidence — zero on bars with no event
+    assert (quiet["wyckoff_event_now"][active == 0] == 0).all()
+
+
+def test_context_exposes_raw_sides():
+    df, hi, lo = _spike_bar(_flat_df(120), I, "rejected")
+    out = detect_all_wyckoff_events(df.copy())
+    ctx = create_wyckoff_context(out, lookback=90, timeframe="TEST")
+    assert hasattr(ctx, "raw_bullish_score") and hasattr(ctx, "raw_bearish_score")
+    # net-dominance behavior unchanged: at most one net side > 0
+    assert min(ctx.bullish_score, ctx.bearish_score) == 0.0
+    # raw sides are the pre-arbitration maxes: raw >= net on the winning side
+    assert ctx.raw_bullish_score >= ctx.bullish_score
+    assert ctx.raw_bearish_score >= ctx.bearish_score
+
+
+def test_spring_b_anchored_subset():
+    """anchored can only fire where the FINAL (state-machine-validated)
+    spring_b fired. Regression guard for the 2026-08-20 bug where the anchor
+    was computed pre-SM and fired 207 times vs spring_b's 146 on the V12
+    store. Uses a noisy random-walk tape so spring_b genuinely fires."""
+    rng = np.random.default_rng(3)
+    n = 3000
+    idx = pd.date_range("2023-01-01", periods=n, freq="1h", tz="UTC")
+    close = 100 * np.exp(rng.normal(0, 0.004, n).cumsum())
+    high = close * (1 + abs(rng.normal(0, 0.003, n)))
+    low = close * (1 - abs(rng.normal(0, 0.003, n)))
+    open_ = np.roll(close, 1); open_[0] = close[0]
+    vol = abs(rng.lognormal(7, 1, n))
+    df = pd.DataFrame({"open": open_, "high": high, "low": low,
+                       "close": close, "volume": vol}, index=idx)
+    out = detect_all_wyckoff_events(df.copy())
+    anchored = out["wyckoff_spring_b_anchored"].astype(bool)
+    spring = out["wyckoff_spring_b"].astype(bool)
+    assert spring.sum() > 0, "fixture must actually fire spring_b"
+    assert (anchored & ~spring).sum() == 0, "anchored must be a subset of spring_b"


### PR DESCRIPTION
## Why
Live audit 2026-08-20: the Wyckoff panel's data is real and causal, but **BC is inverted** (fires on rallies, fwd +1.08%/72h vs +0.45% baseline — it's what lit "M2 Distrib" during a +7% rally), the headline scores are rolling maxima displayed as live gauges, and net-dominance hides one directional side. Root cause in code: BC has no reversal requirement AND `_range_position` is close-based, so rejection tops fail the `at_highs` gate — only strong-close breakouts can fire.

## What (SHADOW columns only — zero trading-path change)
- `detect_climax_v2` (BC/SC): gates on the extreme *reached*; immediate fire needs rejection evidence NOW; euphoric-close candidates confirm causally when reversal completes ≤5 bars (stamped at the confirmation bar, never backfilled)
- `wyckoff_spring_b_anchored`: audit add.31 "highest-leverage fix", post-SM strict subset
- `wyckoff_event_now` / `wyckoff_event_age_h`: per-bar honest gauge (0 when quiet)
- `WyckoffHTFContext.raw_*` + `tf4h/tf1d_*_raw` live keys: pre-arbitration sides

Not in `_ACCUM/_DISTRIB` → cannot touch directional scores, state machine, phases, or any consumer. **Isolation proven**: 33 v1 columns byte-identical with shadow on/off; consumer grep across archetypes/fusion/configs: zero references. Deep-daily buffer deliberately untouched (2026-07-20 FAIL verdict stands).

## Validation (V12 store 2018–2024; baseline +0.45%/72h, +1.11%/168h)
| Signal | n | fwd 72h | fwd 168h |
|---|---|---|---|
| BC v1 (live today) | 643 | **+1.08%** | **+1.92%** (inverted) |
| bc_v2_confirmed | 243 | +0.40% | **+0.24%** (direction fixed) |
| spring_b v1 | 146 | +0.90% | +1.48% |
| **spring_b_anchored** | 100 | **+1.18%** | **+2.25%** |

Tests: 11 new (breakout-vs-climax separation, no-repaint truncation, subset regression guard); wyckoff suite 29 passed; the 5 `test_wyckoff_events.py` failures are pre-existing on main (verified via stash). Live smoke: all 13 shadow keys emitted by `LiveFeatureComputer`.

## After merge
Deploy (separate explicit go) starts live shadow collection. Promotion of v2 to decision inputs requires its own validation study (boost-shaped per Rules 7–10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnSatSxY14rJ1KtJM3p5nj
