### PR TITLE
fix: seller-flow sensor — hourly taker aggregate + store-matching formula (was white noise)

### DIFF
--- a/bin/live/live_feature_computer.py
+++ b/bin/live/live_feature_computer.py
@@ -2389,10 +2389,20 @@ class LiveFeatureComputer:
             else:
                 result['ls_ratio_extreme'] = 0.0
 
-            # taker_imbalance
-            taker = data.get('taker_buy_sell_ratio', 1.0)
-            # Convert ratio to imbalance: ratio=1.0 -> 0, ratio=1.5 -> positive, ratio=0.5 -> negative
-            result['taker_imbalance'] = (taker - 1.0) / max(taker, 0.01) if taker else 0.0
+            # taker_imbalance — SENSOR REPAIR 2026-08-24: compute from the
+            # last COMPLETED hour's buy/sell volumes with the store-matching
+            # formula (buy-sell)/(buy+sell). The old path applied
+            # (r-1)/max(r,0.01) to a just-started bucket (~60s of volume),
+            # yielding white noise (autocorr 0.007) that was NOT the variable
+            # the seller-flow boost was validated on. Fallback keeps the old
+            # ratio-based value only if hourly vols are absent.
+            from bin.live.okx_derivatives_api import taker_imbalance_from_vols
+            _b = data.get('taker_buy_vol_1h'); _s = data.get('taker_sell_vol_1h')
+            if _b is not None and _s is not None:
+                result['taker_imbalance'] = taker_imbalance_from_vols(_b, _s)
+            else:
+                taker = data.get('taker_buy_sell_ratio', 1.0)
+                result['taker_imbalance'] = ((taker - 1.0) / (taker + 1.0)) if taker else 0.0
 
             self._binance_cache = result
             self._binance_last_fetch = now

--- a/bin/live/okx_derivatives_api.py
+++ b/bin/live/okx_derivatives_api.py
@@ -37,6 +37,45 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
+def select_completed_taker_bucket(taker_data, now):
+    """Pick the last COMPLETED 1H taker-volume bucket (SENSOR REPAIR 2026-08-24).
+
+    OKX returns buckets newest-first as [ts_ms, sell_vol, buy_vol]. The runner
+    fetches ~1 minute past the hour, so the head bucket is usually the hour
+    that just STARTED (~60s of volume) — reading it made live taker_imbalance
+    white noise (autocorr 0.007; r=0.017 vs real CME hourly flow). The
+    validated store feature is a full-hour aggregate, so we must select the
+    bucket for the last completed hour by TIMESTAMP, never by position.
+
+    Returns (sell_vol, buy_vol) floats, or None if no completed bucket found.
+    """
+    import pandas as _pd
+    now = _pd.Timestamp(now)
+    if now.tzinfo is None:
+        now = now.tz_localize('UTC')
+    completed = (now.floor('h') - _pd.Timedelta(hours=1)).timestamp() * 1000
+    for row in taker_data or []:
+        try:
+            ts = float(row[0])
+            if abs(ts - completed) < 1:
+                return float(row[1]), float(row[2])
+        except (IndexError, TypeError, ValueError):
+            continue
+    return None
+
+
+def taker_imbalance_from_vols(buy, sell):
+    """Store-matching imbalance: (buy-sell)/(buy+sell) == (r-1)/(r+1), in [-1, 1].
+
+    The old live formula (r-1)/max(r,0.01) had a different scale (std 0.27 vs
+    the store's 0.075) on top of the snapshot bug; this restores the exact
+    definition the seller-flow boost was validated on
+    (derivatives_data_backfill_method.md).
+    """
+    tot = buy + sell
+    return (buy - sell) / tot if tot > 0 else 0.0
+
 BASE_URL = "https://www.okx.com"
 
 
@@ -231,14 +270,18 @@ class OKXDerivativesAPI:
                 {"ccy": ccy, "instType": "CONTRACTS", "period": "1H"},
             )
             if taker_data and len(taker_data) > 0:
-                # Response: list of [timestamp, sell_vol, buy_vol] — newest first
-                try:
-                    sell_vol = float(taker_data[0][1])
-                    buy_vol = float(taker_data[0][2])
+                # Response: list of [timestamp, sell_vol, buy_vol] — newest first.
+                # SENSOR REPAIR 2026-08-24: use the last COMPLETED hour (by
+                # timestamp), never the just-started head bucket. See
+                # select_completed_taker_bucket docstring.
+                import pandas as _pd
+                bucket = select_completed_taker_bucket(taker_data, _pd.Timestamp.utcnow())
+                if bucket is not None:
+                    sell_vol, buy_vol = bucket
+                    result["taker_sell_vol_1h"] = sell_vol
+                    result["taker_buy_vol_1h"] = buy_vol
                     if sell_vol > 0:
                         result["taker_buy_sell_ratio"] = buy_vol / sell_vol
-                except (IndexError, TypeError, ValueError):
-                    pass
         except Exception as exc:
             logger.warning("OKX taker volume failed: %s", exc)
 

--- a/docs/knowledge/sizing_package_verdict_2026_08_24.md
+++ b/docs/knowledge/sizing_package_verdict_2026_08_24.md
@@ -1,0 +1,12 @@
+# Sizing Package — flat-notional + post-impulse dial — VALIDATED (2026-08-24)
+
+Three pre-registered interventional A/Bs, all divergence-verified, entries identical (3,512) in every run:
+| variant | PnL | PF | MaxDD | Sharpe | years up |
+|---|---|---|---|---|---|
+| baseline (ATR-inverse, no dial) | $268.9K | 1.41 | −16.5% | 1.53 | — |
+| flat-notional only | $300.3K (+11.7%) | 1.41 | −16.0% | 1.44 | 5/5 |
+| impulse dial only (1.25x ≤3d post +10%/3d impulse; 0.75x dead; 1.0x base — causal) | $283.9K (+5.6%) | **1.47** | **−13.1%** | **1.62** | 5/5 (bear best) |
+| **COMBINED** | **$307.2K (+14.2%)** | 1.46 | **−13.9%** | 1.54 | **5/5** |
+Per-archetype: wick_trap +19% ($61.0→72.4K), LC up, OBR loss shrinks. Dial de-sizes dead tape → bear-year bleed shrinks (2022 +$5.5K); flat-notional feeds the wide-stop winner class (Q4 = 51% WR, 55% of profits at smallest size under baseline). Effects near-additive; dial fixes flat's Sharpe dip.
+
+**Implementation if approved**: backtest line 1449 → `notional = risk$/0.025 * dial_mult`; live runner needs the same divisor change + daily causal dial from own candle history (r3(daily)≥10% within 3d → 1.25x; 12d range ≤8% → 1.0x; else 0.75x). Sizing-family change (historically 2/2 accepted); honest limits: single instrument, 2020-2024, no offline holdout exists — real OOS = live forward with a 4-week review. NOT applied anywhere yet.

--- a/tests/test_taker_imbalance_hourly.py
+++ b/tests/test_taker_imbalance_hourly.py
@@ -1,0 +1,50 @@
+"""
+Seller-flow sensor repair (2026-08-24): live taker_imbalance must be computed
+from the last COMPLETED 1H taker-volume bucket with the store-matching formula.
+
+Bug (cme_seller_flow_replication_2026_08_20.md): the runner fetches ~1min past
+the hour and read taker_data[0] — the just-STARTED bucket (~60s of volume) —
+then applied (r-1)/max(r,0.01). Result: autocorr 0.007 (white noise), r=0.017
+vs real CME hourly flow. The validated store feature is a full-hour aggregate
+with imbalance = (buy-sell)/(buy+sell) == (r-1)/(r+1).
+"""
+import pandas as pd
+from bin.live.okx_derivatives_api import select_completed_taker_bucket, taker_imbalance_from_vols
+
+
+def _ms(ts): return str(int(pd.Timestamp(ts, tz='UTC').timestamp()*1000))
+
+
+def test_selects_last_completed_hour_not_in_progress():
+    now = pd.Timestamp('2026-08-24 15:01:40', tz='UTC')
+    buckets = [
+        [_ms('2026-08-24 15:00'), '10', '12'],   # in-progress hour — must NOT be used
+        [_ms('2026-08-24 14:00'), '500', '400'], # last completed hour — the answer
+        [_ms('2026-08-24 13:00'), '300', '300'],
+    ]
+    sell, buy = select_completed_taker_bucket(buckets, now)
+    assert (sell, buy) == (500.0, 400.0)
+
+
+def test_selects_head_when_head_is_completed():
+    now = pd.Timestamp('2026-08-24 15:01:40', tz='UTC')
+    buckets = [
+        [_ms('2026-08-24 14:00'), '500', '400'],  # head already the completed hour
+        [_ms('2026-08-24 13:00'), '300', '300'],
+    ]
+    sell, buy = select_completed_taker_bucket(buckets, now)
+    assert (sell, buy) == (500.0, 400.0)
+
+
+def test_returns_none_when_no_completed_bucket():
+    now = pd.Timestamp('2026-08-24 15:01:40', tz='UTC')
+    buckets = [[_ms('2026-08-24 15:00'), '10', '12']]
+    assert select_completed_taker_bucket(buckets, now) is None
+
+
+def test_formula_matches_store_definition():
+    # store: imbalance = (r-1)/(r+1) = (buy-sell)/(buy+sell), bounded [-1, 1]
+    assert abs(taker_imbalance_from_vols(buy=150.0, sell=100.0) - 0.2) < 1e-9
+    assert abs(taker_imbalance_from_vols(buy=100.0, sell=150.0) + 0.2) < 1e-9
+    assert taker_imbalance_from_vols(buy=0.0, sell=0.0) == 0.0
+    assert taker_imbalance_from_vols(buy=100.0, sell=0.0) == 1.0


### PR DESCRIPTION
## Summary
Live `taker_imbalance` was a ~60-second snapshot with a non-validated formula — zero correlation with real hourly flow (CME study, r=0.017, autocorr 0.007). The wick_trap seller-flow boost (1.25x) has been firing on noise. This PR selects the last **completed** 1H OKX taker bucket by timestamp and computes `(buy−sell)/(buy+sell)` — the exact variable the boost was validated on (Binance Vision store definition).

## Live impact (after explicit deploy)
- wick_trap's boost condition starts reading real flow; expected ≤0 share ≈28% of bars (store distribution) vs ~50% coin-flip today
- No thresholds/gates/sizing logic touched; two new logging fields

## Validation
4 new tests (bucket selection, formula); seller-flow + maker-shadow suites pass; live OKX fetch verified returning completed-hour vols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnSatSxY14rJ1KtJM3p5nj