### PR TITLE
feat: CME institutional OI live feed (shadow features, daily Databento fetch)

### DIFF
--- a/bin/live/cme_oi_feed.py
+++ b/bin/live/cme_oi_feed.py
@@ -1,0 +1,194 @@
+"""CME institutional Open Interest live feed (Databento) — SHADOW features.
+
+Why (docs/knowledge/cme_oi_regime_study_2026_08_21.md): oi_divergence re-fed
+with CME daily OI flipped from −$5,334/WR 37% to +$6,804/WR 59% (2021-2024,
+zero tuning) — the archetype's premise was right, its perp-snapshot witness
+was garbage. The live path still reads that witness. This module fetches the
+once-a-day CME settlement OI (GLBX.MDP3 `statistics` schema, stat_type 9)
+and derives CAUSAL daily features under a `cme_` prefix.
+
+SHADOW CONTRACT: nothing in the trading path consumes `cme_*` features.
+Promotion = a later, deliberate config change rewiring oi_divergence's gates
+after live shadow validation. The whale-conflict penalty keeps its perp 4h
+witness permanently (daily-for-4h swap REJECTED: semantics mismatch, −$24.7K).
+
+Causality: CME OI for day D is a settlement figure published after the
+session; we only ever expose the change up to D-1 (yesterday's completed
+settlement), matching the offline study exactly.
+
+Cost: one small statistics request per UTC day (~$0.001 against the
+Databento account). API key read from DATABENTO_API_KEY or ~/.databento_key
+— never from the repo.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_HIST_URL = "https://hist.databento.com/v0/timeseries.get_range"
+_STAT_OPEN_INTEREST = 9  # Databento statistics stat_type for open interest
+
+
+def load_api_key() -> Optional[str]:
+    """DATABENTO_API_KEY env var, else ~/.databento_key file, else None."""
+    key = os.environ.get("DATABENTO_API_KEY", "").strip()
+    if key:
+        return key
+    p = Path.home() / ".databento_key"
+    if p.exists():
+        key = p.read_text().strip()
+        return key or None
+    return None
+
+
+def fetch_daily_oi(api_key: str, lookback_days: int = 10,
+                   symbol: str = "BTC.c.0",
+                   timeout: int = 60) -> pd.Series:
+    """Fetch the last `lookback_days` of daily CME OI settlements.
+
+    Returns a Series of OI (contracts) indexed by UTC-normalized settlement
+    day, sorted, deduped (last wins). Raises on network/HTTP errors — the
+    caller degrades gracefully.
+    """
+    end = pd.Timestamp.utcnow().floor("D")
+    start = end - pd.Timedelta(days=lookback_days)
+    params = urllib.parse.urlencode({
+        "dataset": "GLBX.MDP3",
+        "symbols": symbol,
+        "stype_in": "continuous",
+        "schema": "statistics",
+        "start": start.strftime("%Y-%m-%d"),
+        "end": end.strftime("%Y-%m-%dT%H:%M:%S"),
+        "encoding": "json",
+        "pretty_ts": "true",
+        "map_symbols": "true",
+    })
+    req = urllib.request.Request(f"{_HIST_URL}?{params}")
+    auth = (api_key + ":").encode()
+    import base64
+    req.add_header("Authorization", "Authorization: Basic".split()[0] and
+                   "Basic " + base64.b64encode(auth).decode())
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        lines = r.read().decode().strip().splitlines()
+    rows: List[Dict] = []
+    for line in lines:
+        try:
+            o = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        rec = o.get("record", o)
+        hd = rec.get("hd", {})
+        if int(rec.get("stat_type", -1)) != _STAT_OPEN_INTEREST:
+            continue
+        ts = rec.get("ts_ref") or hd.get("ts_event") or rec.get("ts_event")
+        qty = rec.get("quantity")
+        if ts is None or qty is None:
+            continue
+        rows.append({"ts": ts, "oi": float(qty)})
+    if not rows:
+        return pd.Series(dtype=float)
+    df = pd.DataFrame(rows)
+    df["day"] = pd.to_datetime(df["ts"], utc=True).dt.normalize()
+    s = df.groupby("day")["oi"].last().sort_index()
+    return s
+
+
+def compute_cme_oi_features(oi: pd.Series, price: pd.Series,
+                            now: pd.Timestamp) -> Dict[str, float]:
+    """Derive the causal shadow features from daily OI + daily close series.
+
+    Uses only settlements up to YESTERDAY relative to `now` (t-1 causal),
+    mirroring the offline study. Returns NaNs when history is insufficient —
+    consumers must be nan-safe (they are: nothing consumes these yet).
+
+    Features:
+        cme_oi_value        : yesterday's settlement OI (contracts)
+        cme_oi_change_24h   : yesterday's settlement vs the one before
+        cme_oi_price_divergence : -sign(doi)*sign(dpx)*|doi| (daily analog)
+        cme_oi_age_days     : age of the newest usable settlement (staleness)
+    """
+    out = {
+        "cme_oi_value": np.nan,
+        "cme_oi_change_24h": np.nan,
+        "cme_oi_price_divergence": np.nan,
+        "cme_oi_age_days": np.nan,
+    }
+    now = pd.Timestamp(now)
+    if now.tzinfo is None:
+        now = now.tz_localize("UTC")
+    cutoff = now.normalize() - pd.Timedelta(days=1)
+    oi = oi.dropna()
+    if len(oi) == 0:            # empty series has no DatetimeIndex to compare
+        return out
+    if oi.index.tz is None:
+        oi.index = oi.index.tz_localize("UTC")
+    oi = oi[oi.index <= cutoff]
+    if len(oi) < 2:
+        return out
+    out["cme_oi_value"] = float(oi.iloc[-1])
+    out["cme_oi_age_days"] = float((now.normalize() - oi.index[-1]).days)
+    prev = float(oi.iloc[-2])
+    doi = (float(oi.iloc[-1]) / prev - 1.0) if prev > 0 else np.nan
+    out["cme_oi_change_24h"] = doi
+    if price is not None and len(price.dropna()) >= 2 and doi == doi:
+        px = price.dropna()
+        px = px[px.index <= cutoff]
+        if len(px) >= 2 and float(px.iloc[-2]) > 0:
+            dpx = float(px.iloc[-1]) / float(px.iloc[-2]) - 1.0
+            out["cme_oi_price_divergence"] = float(
+                -np.sign(doi) * np.sign(dpx) * abs(doi))
+    return out
+
+
+class CMEOIFeed:
+    """Once-per-UTC-day fetcher with graceful degradation.
+
+    On failure keeps the previous day's series (features go stale, the
+    cme_oi_age_days field says by how much). Never raises into the runner.
+    """
+
+    _AUTO = "__auto__"
+
+    def __init__(self, api_key: Optional[str] = _AUTO):
+        # api_key=None means explicitly no key (inert feed); the default
+        # sentinel resolves from env/keyfile via load_api_key().
+        self._key = load_api_key() if api_key == self._AUTO else api_key
+        self._oi: pd.Series = pd.Series(dtype=float)
+        self._last_fetch_day: Optional[str] = None
+
+    @property
+    def available(self) -> bool:
+        return self._key is not None
+
+    def refresh_if_needed(self, now: pd.Timestamp) -> None:
+        if not self.available:
+            return
+        day = pd.Timestamp(now).strftime("%Y-%m-%d")
+        if self._last_fetch_day == day:
+            return
+        try:
+            s = fetch_daily_oi(self._key)
+            if len(s) > 0:
+                self._oi = s
+                self._last_fetch_day = day
+                logger.info("[CME_OI] refreshed: %d settlements through %s",
+                            len(s), s.index[-1].date())
+            else:
+                logger.warning("[CME_OI] empty response — keeping previous series")
+        except Exception as exc:  # noqa: BLE001 — never break the bar loop
+            logger.warning("[CME_OI] refresh failed (%s) — keeping previous series", exc)
+
+    def features(self, now: pd.Timestamp,
+                 daily_price: Optional[pd.Series] = None) -> Dict[str, float]:
+        return compute_cme_oi_features(self._oi, daily_price if daily_price
+                                       is not None else pd.Series(dtype=float), now)

--- a/bin/live/coinbase_runner.py
+++ b/bin/live/coinbase_runner.py
@@ -1397,6 +1397,7 @@ class CoinbasePaperRunner:
 
         self.feature_computer.ingest_candles(candles)
         self._refresh_daily_context(force=True)
+        self._refresh_cme_oi()
 
         # Backfill feature_history from warmup candles + historical macro
         # data so correlation and cointegration are ready immediately.
@@ -2715,6 +2716,23 @@ class CoinbasePaperRunner:
         except Exception as exc:
             logger.warning("[BREADTH] alt fetch failed (%s) — feature absent", exc)
 
+    def _refresh_cme_oi(self, timestamp=None):
+        """Daily CME OI shadow-feature refresh (2026-08-24). Never raises;
+        without a Databento key the feed is inert and features stay absent."""
+        try:
+            from bin.live.cme_oi_feed import CMEOIFeed
+            if not hasattr(self, "_cme_oi_feed"):
+                self._cme_oi_feed = CMEOIFeed()
+                if not self._cme_oi_feed.available:
+                    logger.info("[CME_OI] no Databento key — shadow feed inert")
+            if not self._cme_oi_feed.available:
+                return
+            now = pd.Timestamp(timestamp) if timestamp is not None else pd.Timestamp.utcnow()
+            self._cme_oi_feed.refresh_if_needed(now)
+            self.feature_computer.set_cme_oi_features(self._cme_oi_feed.features(now))
+        except Exception as exc:
+            logger.warning("[CME_OI] refresh hook failed (%s) — features unchanged", exc)
+
     def _refresh_daily_context(self, timestamp=None, force=False):
         """Feed ~300 real daily candles into the feature computer's deep
         daily buffer (2026-07-20 upgrade). Once per UTC day; failure keeps
@@ -3240,6 +3258,7 @@ class CoinbasePaperRunner:
 
         # Deep daily context: refresh once per UTC day (cheap single request)
         self._refresh_daily_context(timestamp=timestamp)
+        self._refresh_cme_oi(timestamp=timestamp)
 
         # Compute features (~240 columns)
         try:

--- a/bin/live/live_feature_computer.py
+++ b/bin/live/live_feature_computer.py
@@ -711,6 +711,11 @@ class LiveFeatureComputer:
         logger.info(f"Ingested {len(buf)} daily candles "
                     f"({buf.index[0].date()} to {buf.index[-1].date()})")
 
+    def set_cme_oi_features(self, feats: dict) -> None:
+        """Store the daily CME OI shadow features (set by the runner's daily
+        refresh; merged into every bar's feature vector for logging only)."""
+        self._cme_oi_features = dict(feats) if feats else {}
+
     def update(self, candle: dict) -> pd.Series:
         """
         Process one new candle and return the full feature vector.
@@ -834,6 +839,12 @@ class LiveFeatureComputer:
 
         # P2. Derivatives institutional flow features (OKX/Binance/CoinGlass)
         features.update(self._binance_futures_features())
+
+        # CME institutional OI — SHADOW features (2026-08-24). Set daily by
+        # the runner via set_cme_oi_features(); logged for study, consumed by
+        # NOTHING in the trading path (cme_oi_regime_study_2026_08_21.md).
+        if getattr(self, '_cme_oi_features', None):
+            features.update(self._cme_oi_features)
 
         # Feed derivatives funding rate into _funding_history for Z-score computation.
         # The Z-score needs 10+ historical values to compute — this populates it

--- a/tests/test_cme_oi_feed.py
+++ b/tests/test_cme_oi_feed.py
@@ -1,0 +1,54 @@
+"""CME OI live feed — causality and degradation tests (no network)."""
+import numpy as np
+import pandas as pd
+
+from bin.live.cme_oi_feed import compute_cme_oi_features, CMEOIFeed
+
+
+def _series(vals, start="2026-08-18"):
+    idx = pd.date_range(start, periods=len(vals), freq="1D", tz="UTC")
+    return pd.Series(vals, index=idx, dtype=float)
+
+
+NOW = pd.Timestamp("2026-08-24 15:30", tz="UTC")
+
+
+def test_causal_uses_only_completed_settlements():
+    """Today's (partial/just-published) settlement must never be used."""
+    oi = _series([100, 110, 120, 130, 140, 150, 160])  # last = 2026-08-24 (today)
+    f = compute_cme_oi_features(oi, pd.Series(dtype=float), NOW)
+    assert f["cme_oi_value"] == 150.0  # yesterday (08-23), not today's 160
+    assert abs(f["cme_oi_change_24h"] - (150 / 140 - 1)) < 1e-12
+
+
+def test_staleness_reported():
+    oi = _series([100, 110], start="2026-08-18")  # newest = 08-19, 5 days old
+    f = compute_cme_oi_features(oi, pd.Series(dtype=float), NOW)
+    assert f["cme_oi_age_days"] == 5.0
+    assert f["cme_oi_value"] == 110.0
+
+
+def test_insufficient_history_is_nan():
+    f = compute_cme_oi_features(_series([100])[:1], pd.Series(dtype=float), NOW)
+    assert np.isnan(f["cme_oi_value"]) and np.isnan(f["cme_oi_change_24h"])
+
+
+def test_divergence_sign_matches_study_definition():
+    # price up, OI down -> hollow move -> positive divergence (study formula)
+    oi = _series([100, 110, 105, 100, 95])           # falling into 08-22
+    px = _series([50000, 50500, 51000, 51500, 52000])
+    now = pd.Timestamp("2026-08-23 12:00", tz="UTC")
+    f = compute_cme_oi_features(oi, px, now)
+    assert f["cme_oi_price_divergence"] > 0
+    # price up, OI up -> backed move -> negative divergence
+    oi2 = _series([100, 105, 110, 115, 120])
+    f2 = compute_cme_oi_features(oi2, px, now)
+    assert f2["cme_oi_price_divergence"] < 0
+
+
+def test_feed_without_key_is_inert():
+    feed = CMEOIFeed(api_key=None)
+    assert not feed.available
+    feed.refresh_if_needed(NOW)  # must not raise, must not fetch
+    f = feed.features(NOW)
+    assert np.isnan(f["cme_oi_value"])


### PR DESCRIPTION
## Summary
Live shadow feed for the one place CME OI is proven to matter (oi_divergence: −$5.3K → +$6.8K, WR 37→59%, zero tuning — `cme_oi_regime_study_2026_08_21.md`). Fetches yesterday's CME settlement OI once per UTC day (~$0.001), derives causal `cme_oi_value/change_24h/price_divergence/age_days`, logs them on every bar.

## Live impact
**Zero trading change** — consumer grep clean; nothing reads `cme_*`. Whale penalty keeps its perp witness (daily swap rejected: −$24.7K semantics mismatch). Promotion of oi_divergence's gates to CME is a separate future PR after live shadow validation.

## Deploy note
Server needs the Databento key at `~/.databento_key` (or `DATABENTO_API_KEY`) — copied at deploy, never committed. Without it the feed logs one line and stays inert.

## Validation
5 tests (causality, staleness, keyless inertness); live fetch verified (7 settlements, OI 11,882, −5.5%/day — the hollow-rally signature currently live); full smoke through the feature computer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnSatSxY14rJ1KtJM3p5nj