### PR TITLE
fix: CME OI feed availability clamp + honest NaN handling

### DIFF
--- a/bin/live/cme_oi_feed.py
+++ b/bin/live/cme_oi_feed.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -73,13 +74,36 @@ def fetch_daily_oi(api_key: str, lookback_days: int = 10,
         "pretty_ts": "true",
         "map_symbols": "true",
     })
-    req = urllib.request.Request(f"{_HIST_URL}?{params}")
-    auth = (api_key + ":").encode()
     import base64
-    req.add_header("Authorization", "Authorization: Basic".split()[0] and
-                   "Basic " + base64.b64encode(auth).decode())
-    with urllib.request.urlopen(req, timeout=timeout) as r:
-        lines = r.read().decode().strip().splitlines()
+    def _get(url):
+        req = urllib.request.Request(url)
+        req.add_header("Authorization",
+                       "Basic " + base64.b64encode((api_key + ":").encode()).decode())
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read().decode().strip().splitlines()
+    try:
+        lines = _get(f"{_HIST_URL}?{params}")
+    except urllib.error.HTTPError as e:
+        # Databento's statistics availability lags ~1 day (+weekends); an end
+        # beyond available_end 422s. Parse available_end and retry clamped.
+        if e.code != 422:
+            raise
+        try:
+            body = json.loads(e.read().decode())
+            avail = (body.get("detail", {}).get("payload", {})
+                     or {}).get("available_end")
+        except Exception:
+            avail = None
+        if not avail:
+            raise
+        clamped = pd.Timestamp(avail).tz_convert("UTC") if pd.Timestamp(avail).tzinfo             else pd.Timestamp(avail, tz="UTC")
+        params2 = urllib.parse.urlencode({
+            "dataset": "GLBX.MDP3", "symbols": symbol, "stype_in": "continuous",
+            "schema": "statistics", "start": start.strftime("%Y-%m-%d"),
+            "end": clamped.strftime("%Y-%m-%dT%H:%M:%S"),
+            "encoding": "json", "pretty_ts": "true", "map_symbols": "true",
+        })
+        lines = _get(f"{_HIST_URL}?{params2}")
     rows: List[Dict] = []
     for line in lines:
         try:

--- a/bin/live/live_feature_computer.py
+++ b/bin/live/live_feature_computer.py
@@ -844,7 +844,11 @@ class LiveFeatureComputer:
         # the runner via set_cme_oi_features(); logged for study, consumed by
         # NOTHING in the trading path (cme_oi_regime_study_2026_08_21.md).
         if getattr(self, '_cme_oi_features', None):
-            features.update(self._cme_oi_features)
+            # merge only real values: NaN would be coerced to a misleading 0.0
+            # by the JSON feature logger (age 0.0 = "fresh" is a lie; absent
+            # keys are honest).
+            features.update({k: v for k, v in self._cme_oi_features.items()
+                             if v == v})
 
         # Feed derivatives funding rate into _funding_history for Z-score computation.
         # The Z-score needs 10+ historical values to compute — this populates it


### PR DESCRIPTION
Hotfix completing #68's deployment: (1) 422 from Databento (statistics availability lags ~1d+weekends) now handled by clamping end to the API's available_end and retrying; (2) NaN cme_* values are omitted rather than logged as misleading 0.0 by the JSON logger. Live fetch verified post-fix. Shadow-only; no trading path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnSatSxY14rJ1KtJM3p5nj